### PR TITLE
Fixes and optimizations

### DIFF
--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
+    <string name="staking_no_controller_account">Controller account %s is unavailable to update staking setup.</string>
+
     <string name="staking_manage">Manage</string>
     <string name="staking_stake_more">Stake more</string>
     <string name="staking_pause_staking">Pause staking</string>

--- a/core-db/src/main/java/jp/co/soramitsu/core_db/dao/AccountDao.kt
+++ b/core-db/src/main/java/jp/co/soramitsu/core_db/dao/AccountDao.kt
@@ -5,8 +5,8 @@ import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import androidx.room.Update
-import jp.co.soramitsu.core_db.model.AccountLocal
 import jp.co.soramitsu.core.model.Node
+import jp.co.soramitsu.core_db.model.AccountLocal
 import kotlinx.coroutines.flow.Flow
 
 @Dao
@@ -41,4 +41,7 @@ abstract class AccountDao {
 
     @Query("select * from users where (address LIKE '%' || :query  || '%') AND networkType = :networkType")
     abstract suspend fun getAccounts(query: String, networkType: Node.NetworkType): List<AccountLocal>
+
+    @Query("SELECT EXISTS(SELECT * FROM users WHERE address = :accountAddress)")
+    abstract suspend fun accountExists(accountAddress: String): Boolean
 }

--- a/feature-account-api/src/main/java/jp/co/soramitsu/feature_account_api/domain/interfaces/AccountRepository.kt
+++ b/feature-account-api/src/main/java/jp/co/soramitsu/feature_account_api/domain/interfaces/AccountRepository.kt
@@ -132,4 +132,6 @@ interface AccountRepository {
     fun createQrAccountContent(account: Account): String
 
     suspend fun generateRestoreJson(account: Account, password: String): String
+
+    suspend fun isAccountExists(accountAddress: String): Boolean
 }

--- a/feature-account-impl/src/main/java/jp/co/soramitsu/feature_account_impl/data/repository/AccountRepositoryImpl.kt
+++ b/feature-account-impl/src/main/java/jp/co/soramitsu/feature_account_impl/data/repository/AccountRepositoryImpl.kt
@@ -348,6 +348,10 @@ class AccountRepositoryImpl(
         }
     }
 
+    override suspend fun isAccountExists(accountAddress: String): Boolean {
+        return accountDao.accountExists(accountAddress)
+    }
+
     override fun nodesFlow(): Flow<List<Node>> {
         return nodeDao.nodesFlow()
             .mapList { mapNodeLocalToNode(it) }

--- a/feature-staking-impl/src/main/java/jp/co/soramitsu/feature_staking_impl/domain/model/SetupStakingPayload.kt
+++ b/feature-staking-impl/src/main/java/jp/co/soramitsu/feature_staking_impl/domain/model/SetupStakingPayload.kt
@@ -1,13 +1,11 @@
 package jp.co.soramitsu.feature_staking_impl.domain.model
 
-import jp.co.soramitsu.feature_staking_api.domain.model.RewardDestination
 import jp.co.soramitsu.feature_wallet_api.domain.model.Token
 import java.math.BigDecimal
 
 class SetupStakingPayload(
     val amount: BigDecimal,
     val tokenType: Token.Type,
-    val originAddress: String,
     val maxFee: BigDecimal,
-    val rewardDestination: RewardDestination,
+    val stashSetup: StashSetup
 )

--- a/feature-staking-impl/src/main/java/jp/co/soramitsu/feature_staking_impl/domain/model/StashSetup.kt
+++ b/feature-staking-impl/src/main/java/jp/co/soramitsu/feature_staking_impl/domain/model/StashSetup.kt
@@ -1,0 +1,9 @@
+package jp.co.soramitsu.feature_staking_impl.domain.model
+
+import jp.co.soramitsu.feature_staking_api.domain.model.RewardDestination
+
+class StashSetup(
+    val rewardDestination: RewardDestination,
+    val controllerAddress: String,
+    val alreadyHasStash: Boolean,
+)

--- a/feature-staking-impl/src/main/java/jp/co/soramitsu/feature_staking_impl/domain/setup/validations/EnoughToPayFeesValidation.kt
+++ b/feature-staking-impl/src/main/java/jp/co/soramitsu/feature_staking_impl/domain/setup/validations/EnoughToPayFeesValidation.kt
@@ -14,7 +14,7 @@ class EnoughToPayFeesValidation(
 ) : Validation<SetupStakingPayload, StakingValidationFailure> {
 
     override suspend fun validate(value: SetupStakingPayload): ValidationStatus<StakingValidationFailure> {
-        val account = accountRepository.getAccount(value.originAddress)
+        val account = accountRepository.getAccount(value.stashSetup.controllerAddress)
         val asset = walletRepository.getAsset(mapAccountToWalletAccount(account), value.tokenType)!!
 
         return if (value.amount + value.maxFee < asset.transferable) {

--- a/feature-staking-impl/src/main/java/jp/co/soramitsu/feature_staking_impl/presentation/common/fee/FeeLoaderMixin.kt
+++ b/feature-staking-impl/src/main/java/jp/co/soramitsu/feature_staking_impl/presentation/common/fee/FeeLoaderMixin.kt
@@ -2,7 +2,6 @@ package jp.co.soramitsu.feature_staking_impl.presentation.common.fee
 
 import androidx.lifecycle.LiveData
 import jp.co.soramitsu.common.mixin.api.Retriable
-import jp.co.soramitsu.feature_staking_api.domain.model.StakingAccount
 import jp.co.soramitsu.feature_staking_impl.presentation.common.model.FeeModel
 import jp.co.soramitsu.feature_wallet_api.domain.model.Asset
 import kotlinx.coroutines.CoroutineScope
@@ -24,7 +23,7 @@ interface FeeLoaderMixin : Retriable {
 
         fun loadFee(
             coroutineScope: CoroutineScope,
-            feeConstructor: suspend (StakingAccount, Asset) -> BigDecimal,
+            feeConstructor: suspend (Asset) -> BigDecimal,
             onRetryCancelled: () -> Unit
         )
 

--- a/feature-staking-impl/src/main/java/jp/co/soramitsu/feature_staking_impl/presentation/common/fee/FeeLoaderProvider.kt
+++ b/feature-staking-impl/src/main/java/jp/co/soramitsu/feature_staking_impl/presentation/common/fee/FeeLoaderProvider.kt
@@ -4,7 +4,6 @@ import androidx.lifecycle.MutableLiveData
 import jp.co.soramitsu.common.mixin.api.RetryPayload
 import jp.co.soramitsu.common.resources.ResourceManager
 import jp.co.soramitsu.common.utils.Event
-import jp.co.soramitsu.feature_staking_api.domain.model.StakingAccount
 import jp.co.soramitsu.feature_staking_impl.R
 import jp.co.soramitsu.feature_staking_impl.domain.StakingInteractor
 import jp.co.soramitsu.feature_staking_impl.presentation.common.mapFeeToFeeModel
@@ -26,18 +25,17 @@ class FeeLoaderProvider(
 
     override fun loadFee(
         coroutineScope: CoroutineScope,
-        feeConstructor: suspend (StakingAccount, Asset) -> BigDecimal,
+        feeConstructor: suspend (Asset) -> BigDecimal,
         onRetryCancelled: () -> Unit
     ) {
         feeLiveData.value = FeeStatus.Loading
 
         coroutineScope.launch(Dispatchers.Default) {
-            val account = stakingInteractor.getSelectedAccount()
             val asset = stakingInteractor.currentAssetFlow().first()
             val token = asset.token
 
             val feeResult = runCatching {
-                feeConstructor(account, asset)
+                feeConstructor(asset)
             }
 
             val value = if (feeResult.isSuccess) {

--- a/feature-staking-impl/src/main/java/jp/co/soramitsu/feature_staking_impl/presentation/staking/StakingFragment.kt
+++ b/feature-staking-impl/src/main/java/jp/co/soramitsu/feature_staking_impl/presentation/staking/StakingFragment.kt
@@ -145,6 +145,8 @@ class StakingFragment : BaseFragment<StakingViewModel>() {
 
         viewModel.networkInfoStateLiveData.observe { state ->
             when (state) {
+                is LoadingState.Loading<*> -> stakingNetworkInfo.showLoading()
+
                 is LoadingState.Loaded<StakingNetworkInfoModel> -> {
                     with(state.data) {
                         stakingNetworkInfo.hideLoading()

--- a/feature-staking-impl/src/main/java/jp/co/soramitsu/feature_staking_impl/presentation/staking/StakingViewModel.kt
+++ b/feature-staking-impl/src/main/java/jp/co/soramitsu/feature_staking_impl/presentation/staking/StakingViewModel.kt
@@ -40,7 +40,7 @@ class StakingViewModel(
     private val currentAssetFlow = interactor.currentAssetFlow()
         .share()
 
-    val currentStakingState = interactor.selectedAccountStakingState()
+    val currentStakingState = interactor.selectedAccountStakingStateFlow()
         .map { transformStakingState(it) }
         .flowOn(Dispatchers.Default)
         .share()
@@ -83,9 +83,9 @@ class StakingViewModel(
             ::showError
         )
 
-        is StakingState.Stash.None -> stakingViewStateFactory.createWelcomeViewState(currentAssetFlow, accountStakingState, viewModelScope)
+        is StakingState.Stash.None -> stakingViewStateFactory.createWelcomeViewState(currentAssetFlow, accountStakingState, viewModelScope, ::showError)
 
-        is StakingState.NonStash -> stakingViewStateFactory.createWelcomeViewState(currentAssetFlow, accountStakingState, viewModelScope)
+        is StakingState.NonStash -> stakingViewStateFactory.createWelcomeViewState(currentAssetFlow, accountStakingState, viewModelScope, ::showError)
 
         is StakingState.Stash.Validator -> stakingViewStateFactory.createValidatorViewState()
     }

--- a/feature-staking-impl/src/main/java/jp/co/soramitsu/feature_staking_impl/presentation/staking/StakingViewModel.kt
+++ b/feature-staking-impl/src/main/java/jp/co/soramitsu/feature_staking_impl/presentation/staking/StakingViewModel.kt
@@ -22,6 +22,7 @@ import jp.co.soramitsu.feature_wallet_api.domain.model.amountFromPlanks
 import jp.co.soramitsu.feature_wallet_api.presentation.formatters.formatWithDefaultPrecision
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
@@ -33,7 +34,7 @@ class StakingViewModel(
     private val addressIconGenerator: AddressIconGenerator,
     private val stakingViewStateFactory: StakingViewStateFactory,
     private val router: StakingRouter,
-    private val resourceManager: ResourceManager
+    private val resourceManager: ResourceManager,
 ) : BaseViewModel() {
 
     private val currentAssetFlow = interactor.currentAssetFlow()
@@ -44,11 +45,12 @@ class StakingViewModel(
         .flowOn(Dispatchers.Default)
         .share()
 
-    val networkInfoStateLiveData = currentAssetFlow
+    val networkInfoStateLiveData = interactor.selectedNetworkTypeFLow()
         .distinctUntilChanged()
-        .withLoading { asset ->
-            interactor.observeNetworkInfoState(asset.token.type.networkType)
-                .map { transformNetworkInfo(asset, it) }
+        .withLoading { networkType ->
+            interactor.observeNetworkInfoState(networkType).combine(currentAssetFlow) { networkInfo, asset ->
+                transformNetworkInfo(asset, networkInfo)
+            }
         }
         .flowOn(Dispatchers.Default)
         .asLiveData()

--- a/feature-staking-impl/src/main/java/jp/co/soramitsu/feature_staking_impl/presentation/staking/di/StakingViewStateFactory.kt
+++ b/feature-staking-impl/src/main/java/jp/co/soramitsu/feature_staking_impl/presentation/staking/di/StakingViewStateFactory.kt
@@ -26,7 +26,8 @@ class StakingViewStateFactory(
     fun createWelcomeViewState(
         currentAssetFlow: Flow<Asset>,
         accountStakingState: StakingState,
-        scope: CoroutineScope
+        scope: CoroutineScope,
+        errorDisplayer: (String) -> Unit
     ) = WelcomeViewState(
         setupStakingSharedState,
         rewardCalculatorFactory,
@@ -35,7 +36,8 @@ class StakingViewStateFactory(
         router,
         accountStakingState,
         currentAssetFlow,
-        scope
+        scope,
+        errorDisplayer
     )
 
     fun createNominatorViewState(

--- a/feature-staking-impl/src/main/java/jp/co/soramitsu/feature_staking_impl/presentation/validators/Common.kt
+++ b/feature-staking-impl/src/main/java/jp/co/soramitsu/feature_staking_impl/presentation/validators/Common.kt
@@ -2,10 +2,8 @@ package jp.co.soramitsu.feature_staking_impl.presentation.validators
 
 import jp.co.soramitsu.feature_staking_api.domain.model.Validator
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
 
-suspend fun Flow<List<Validator>>.findSelectedValidator(accountIdHex: String) = withContext(Dispatchers.Default) {
-    first().firstOrNull { it.accountIdHex == accountIdHex }
+suspend fun List<Validator>.findSelectedValidator(accountIdHex: String) = withContext(Dispatchers.Default) {
+    firstOrNull { it.accountIdHex == accountIdHex }
 }


### PR DESCRIPTION
* Fix active nominators calculation
* Fix multiple recalculations of network info on account change
* Show shimmering for cross-network account changes
* Different controller for stash-only staking setup flow
