### PR TITLE
Fix/calculate payouts

### DIFF
--- a/feature-staking-impl/src/main/java/jp/co/soramitsu/feature_staking_impl/data/network/subscan/SubscanValidatorSetFetcher.kt
+++ b/feature-staking-impl/src/main/java/jp/co/soramitsu/feature_staking_impl/data/network/subscan/SubscanValidatorSetFetcher.kt
@@ -42,9 +42,9 @@ internal typealias GenericParams = List<CallArg<Any?>>
 internal fun GenericParams.argumentValue(name: String): Any? = firstOrNull { it.name == name }?.value
 
 internal class CallDescription(
-    @SerializedName("call_args")
+    @SerializedName("call_args", alternate = ["params"])
     val callArgs: List<CallArg<Any?>>,
-    @SerializedName("call_function")
+    @SerializedName("call_function", alternate = ["call_name"])
     val callFunction: String,
     @SerializedName("call_index")
     val callIndex: String,

--- a/feature-staking-impl/src/main/java/jp/co/soramitsu/feature_staking_impl/data/repository/PayoutRepository.kt
+++ b/feature-staking-impl/src/main/java/jp/co/soramitsu/feature_staking_impl/data/repository/PayoutRepository.kt
@@ -111,7 +111,7 @@ class PayoutRepository(
 
         val nominatorReward = validatorTotalReward * (1 - validatorCommission) * (nominatorStakeInEra / validatorTotalStake)
 
-        return nominatorReward.toInt().toBigInteger()
+        return nominatorReward.toBigDecimal().toBigInteger()
     }
 
     private suspend fun getValidatorHistoricalStats(


### PR DESCRIPTION
* **Handle subscan different response structure for batch params** - Subscan sometimes returns "call_name" instead of "call_function" field. The same for "params" -> "call_args"

* Fix - integer overflow during payout calculation