### PR TITLE
Fix - node is not selected on clean start for Kusama account

### DIFF
--- a/feature-account-api/src/main/java/jp/co/soramitsu/feature_account_api/domain/interfaces/AccountRepository.kt
+++ b/feature-account-api/src/main/java/jp/co/soramitsu/feature_account_api/domain/interfaces/AccountRepository.kt
@@ -19,7 +19,7 @@ interface AccountRepository {
 
     suspend fun getNetworks(): List<Network>
 
-    suspend fun getSelectedNode(): Node
+    suspend fun getSelectedNodeOrDefault(): Node
 
     suspend fun selectNode(node: Node)
 

--- a/feature-account-api/src/main/java/jp/co/soramitsu/feature_account_api/domain/interfaces/AccountRepositoryExt.kt
+++ b/feature-account-api/src/main/java/jp/co/soramitsu/feature_account_api/domain/interfaces/AccountRepositoryExt.kt
@@ -7,7 +7,7 @@ import jp.co.soramitsu.feature_account_api.domain.model.Account
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
-suspend fun AccountRepository.currentNetworkType() = getSelectedNode().networkType
+suspend fun AccountRepository.currentNetworkType() = getSelectedNodeOrDefault().networkType
 
 suspend fun AccountRepository.signWithAccount(account: Account, message: ByteArray) = withContext(Dispatchers.Default) {
     val securitySource = getSecuritySource(account.address)

--- a/feature-account-api/src/main/java/jp/co/soramitsu/feature_account_api/domain/updaters/AccountUpdateScope.kt
+++ b/feature-account-api/src/main/java/jp/co/soramitsu/feature_account_api/domain/updaters/AccountUpdateScope.kt
@@ -13,7 +13,7 @@ class AccountUpdateScope(
 ) : UpdateScope {
 
     override suspend fun invalidationFlow(): Flow<Any> {
-        val networkType = accountRepository.getSelectedNode().networkType
+        val networkType = accountRepository.getSelectedNodeOrDefault().networkType
 
         return accountRepository.selectedAccountFlow()
             .filter { it.network.type == networkType }

--- a/feature-account-impl/src/main/java/jp/co/soramitsu/feature_account_impl/data/repository/AccountRepositoryImpl.kt
+++ b/feature-account-impl/src/main/java/jp/co/soramitsu/feature_account_impl/data/repository/AccountRepositoryImpl.kt
@@ -83,7 +83,7 @@ class AccountRepositoryImpl(
         }
     }
 
-    override suspend fun getSelectedNode(): Node {
+    override suspend fun getSelectedNodeOrDefault(): Node {
         return accountDataSource.getSelectedNode() ?: mapNodeLocalToNode(nodeDao.getFirstNode())
     }
 
@@ -107,7 +107,7 @@ class AccountRepositoryImpl(
                 selectNode(newNode)
             }
 
-            account.network.type != getSelectedNode().networkType -> {
+            account.network.type != accountDataSource.getSelectedNode()?.networkType -> {
                 val defaultNode = getDefaultNode(account.address.networkType())
 
                 selectNode(defaultNode)

--- a/feature-account-impl/src/main/java/jp/co/soramitsu/feature_account_impl/domain/AccountInteractorImpl.kt
+++ b/feature-account-impl/src/main/java/jp/co/soramitsu/feature_account_impl/domain/AccountInteractorImpl.kt
@@ -138,7 +138,7 @@ class AccountInteractorImpl(
         return accountRepository.getNetworks()
     }
 
-    override suspend fun getSelectedNode() = accountRepository.getSelectedNode()
+    override suspend fun getSelectedNode() = accountRepository.getSelectedNodeOrDefault()
 
     override fun groupedAccountsFlow(): Flow<List<Any>> {
         return accountRepository.accountsFlow()
@@ -258,7 +258,7 @@ class AccountInteractorImpl(
 
     override suspend fun getAccountsByNetworkTypeWithSelectedNode(networkType: Node.NetworkType): Pair<List<Account>, Node> {
         val accounts = accountRepository.getAccountsByNetworkType(networkType)
-        val node = accountRepository.getSelectedNode()
+        val node = accountRepository.getSelectedNodeOrDefault()
         return Pair(accounts, node)
     }
 

--- a/feature-crowdloan-impl/src/main/java/jp/co/soramitsu/feature_crowdloan_impl/data/repository/CrowdloanRepositoryImpl.kt
+++ b/feature-crowdloan-impl/src/main/java/jp/co/soramitsu/feature_crowdloan_impl/data/repository/CrowdloanRepositoryImpl.kt
@@ -51,7 +51,7 @@ class CrowdloanRepositoryImpl(
 
     override suspend fun getParachainMetadata(): Map<ParaId, ParachainMetadata> {
         return withContext(Dispatchers.Default) {
-            val networkType = accountRepository.getSelectedNode().networkType
+            val networkType = accountRepository.getSelectedNodeOrDefault().networkType
 
             parachainMetadataApi.getParachainMetadata(networkType.runtimeCacheName())
                 .associateBy { it.paraid }

--- a/feature-staking-impl/src/main/java/jp/co/soramitsu/feature_staking_impl/data/network/blockhain/updaters/ValidatorExposureUpdater.kt
+++ b/feature-staking-impl/src/main/java/jp/co/soramitsu/feature_staking_impl/data/network/blockhain/updaters/ValidatorExposureUpdater.kt
@@ -30,7 +30,7 @@ class ValidatorExposureUpdater(
     override suspend fun listenForUpdates(storageSubscriptionBuilder: SubscriptionBuilder): Flow<Updater.SideEffect> {
         val runtime = runtimeProperty.get()
 
-        return storageCache.observeActiveEraIndex(runtime, accountRepository.getSelectedNode().networkType)
+        return storageCache.observeActiveEraIndex(runtime, accountRepository.getSelectedNodeOrDefault().networkType)
             .map { eraStakersPrefix(runtime, it) }
             .filterNot(storageCache::isPrefixInCache)
             .onEach(::updateNominatorsForEra)

--- a/feature-staking-impl/src/main/java/jp/co/soramitsu/feature_staking_impl/data/network/blockhain/updaters/historical/HistoricalUpdateMediator.kt
+++ b/feature-staking-impl/src/main/java/jp/co/soramitsu/feature_staking_impl/data/network/blockhain/updaters/historical/HistoricalUpdateMediator.kt
@@ -38,7 +38,7 @@ class HistoricalUpdateMediator(
     override suspend fun listenForUpdates(storageSubscriptionBuilder: SubscriptionBuilder): Flow<Updater.SideEffect> {
         val runtime = runtimeProperty.get()
 
-        return storageCache.observeActiveEraIndex(runtime, accountRepository.getSelectedNode().networkType)
+        return storageCache.observeActiveEraIndex(runtime, accountRepository.getSelectedNodeOrDefault().networkType)
             .map {
                 val allKeysNeeded = constructHistoricalKeys(runtime)
                 val keysInDataBase = storageCache.filterKeysInCache(allKeysNeeded).toSet()

--- a/feature-staking-impl/src/main/java/jp/co/soramitsu/feature_staking_impl/domain/StakingInteractor.kt
+++ b/feature-staking-impl/src/main/java/jp/co/soramitsu/feature_staking_impl/domain/StakingInteractor.kt
@@ -192,7 +192,7 @@ class StakingInteractor(
     }
 
     suspend fun getSelectedNetworkType(): Node.NetworkType {
-        return accountRepository.getSelectedNode().networkType
+        return accountRepository.getSelectedNodeOrDefault().networkType
     }
 
     fun selectedAccountFlow(): Flow<StakingAccount> {

--- a/runtime/src/main/java/jp/co/soramitsu/runtime/RuntimeUpdater.kt
+++ b/runtime/src/main/java/jp/co/soramitsu/runtime/RuntimeUpdater.kt
@@ -96,7 +96,7 @@ class RuntimeUpdater(
     private fun errorStatus(): RuntimePreparationStatus.Error = RuntimePreparationStatus.Error(::performUpdate)
 
     private suspend fun getCurrentNetworkName(): String {
-        val networkType = accountRepository.getSelectedNode().networkType
+        val networkType = accountRepository.getSelectedNodeOrDefault().networkType
 
         return networkType.runtimeCacheName()
     }

--- a/runtime/src/main/java/jp/co/soramitsu/runtime/storage/NetworkAwareStorageCache.kt
+++ b/runtime/src/main/java/jp/co/soramitsu/runtime/storage/NetworkAwareStorageCache.kt
@@ -25,7 +25,7 @@ class NetworkAwareStorageCache(
     private val accountRepository: AccountRepository
 ) : StorageCache {
 
-    private suspend fun currentNetwork() = accountRepository.getSelectedNode().networkType
+    private suspend fun currentNetwork() = accountRepository.getSelectedNodeOrDefault().networkType
 
     override suspend fun isPrefixInCache(prefixKey: String): Boolean {
         return storageDao.isPrefixInCache(currentNetwork(), prefixKey)


### PR DESCRIPTION
The bug was caused by the current network type being compared with `getSelectedNode().networkType`, which implicitly returned the default value (first node) if no node was selected (clean run). And it happens that the first node is Kusama one, so no node was selected for the Kusama network since the comparison was successful.

Fixed - changed naming for getSelectedNode to reflect defaulting behavior and changing the abovementioned call to `accountDataSource.getSelectedNode()`, which  does not provide default value

Note that comparison of any network type with `null` will yield `false`, so node selection logic is covered by such comparison as well.