### PR TITLE
Enable cap exceeded validation in DI

### DIFF
--- a/feature-crowdloan-impl/src/main/java/jp/co/soramitsu/feature_crowdloan_impl/di/validations/ContributeValidationsModule.kt
+++ b/feature-crowdloan-impl/src/main/java/jp/co/soramitsu/feature_crowdloan_impl/di/validations/ContributeValidationsModule.kt
@@ -41,7 +41,7 @@ class ContributeValidationsModule {
     @Provides
     @IntoSet
     @FeatureScope
-    fun provideCapExceededValidation() = CapExceededValidation()
+    fun provideCapExceededValidation(): ContributeValidation = CapExceededValidation()
 
     @Provides
     @IntoSet


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/70131744/120802908-a5370e80-c54b-11eb-9b5c-8a853195943a.png)

The problem was caused by Dagger putting into set only instances provided directly with ContributeValidation type. Instances of subtypes are ignored.