### PR TITLE
Fix - clear filters is always enabled

### DIFF
--- a/feature-staking-impl/src/main/java/jp/co/soramitsu/feature_staking_impl/domain/recommendations/ValidatorRecommendator.kt
+++ b/feature-staking-impl/src/main/java/jp/co/soramitsu/feature_staking_impl/domain/recommendations/ValidatorRecommendator.kt
@@ -9,7 +9,7 @@ import kotlinx.coroutines.withContext
 class ValidatorRecommendator(val availableValidators: List<Validator>) {
 
     suspend fun recommendations(settings: RecommendationSettings) = withContext(Dispatchers.Default) {
-        val all = availableValidators.applyFilters(settings.filters)
+        val all = availableValidators.applyFilters(settings.allFilters)
             .sortedWith(settings.sorting)
 
         val postprocessed = settings.postProcessors.fold(all) { acc, postProcessor ->

--- a/feature-staking-impl/src/main/java/jp/co/soramitsu/feature_staking_impl/domain/recommendations/settings/RecommendationSettings.kt
+++ b/feature-staking-impl/src/main/java/jp/co/soramitsu/feature_staking_impl/domain/recommendations/settings/RecommendationSettings.kt
@@ -9,8 +9,12 @@ typealias RecommendationSorting = Comparator<Validator>
 typealias RecommendationPostProcessor = (List<Validator>) -> List<Validator>
 
 data class RecommendationSettings(
-    val filters: List<RecommendationFilter>,
+    val alwaysEnabledFilters: List<RecommendationFilter>,
+    val customEnabledFilters: List<RecommendationFilter>,
     val postProcessors: List<RecommendationPostProcessor>,
     val sorting: RecommendationSorting,
     val limit: Int? = null
-)
+) {
+
+    val allFilters = alwaysEnabledFilters + customEnabledFilters
+}

--- a/feature-staking-impl/src/main/java/jp/co/soramitsu/feature_staking_impl/domain/recommendations/settings/RecommendationSettingsProvider.kt
+++ b/feature-staking-impl/src/main/java/jp/co/soramitsu/feature_staking_impl/domain/recommendations/settings/RecommendationSettingsProvider.kt
@@ -24,8 +24,6 @@ class RecommendationSettingsProvider(
         NotOverSubscribedFilter(maximumRewardedNominators)
     )
 
-    private val allFilters = alwaysEnabledFilters + customizableFilters
-
     private val allPostProcessors = listOf(
         RemoveClusteringPostprocessor
     )
@@ -33,21 +31,16 @@ class RecommendationSettingsProvider(
     private val customSettingsFlow = MutableStateFlow(defaultSelectCustomSettings())
 
     fun createModifiedCustomValidatorsSettings(
-        filterIncluder: ((RecommendationFilter) -> Boolean)? = null,
-        postProcessorIncluder: ((RecommendationPostProcessor) -> Boolean)? = null,
+        filterIncluder: (RecommendationFilter) -> Boolean,
+        postProcessorIncluder: (RecommendationPostProcessor) -> Boolean,
         sorting: RecommendationSorting? = null
     ): RecommendationSettings {
         val current = customSettingsFlow.value
 
-        val filters = filterIncluder?.let { alwaysEnabledFilters + customizableFilters.filter(it) }
-            ?: current.filters
-
-        val postProcessors = postProcessorIncluder?.let { allPostProcessors.filter(it) }
-            ?: current.postProcessors
-
         return current.copy(
-            filters = filters,
-            postProcessors = postProcessors,
+            alwaysEnabledFilters = alwaysEnabledFilters,
+            customEnabledFilters = customizableFilters.filter(filterIncluder),
+            postProcessors = allPostProcessors.filter(postProcessorIncluder),
             sorting = sorting ?: current.sorting
         )
     }
@@ -62,7 +55,8 @@ class RecommendationSettingsProvider(
 
     fun defaultSettings(): RecommendationSettings {
         return RecommendationSettings(
-            filters = allFilters,
+            alwaysEnabledFilters = alwaysEnabledFilters,
+            customEnabledFilters = customizableFilters,
             sorting = APYSorting,
             postProcessors = allPostProcessors,
             limit = maximumValidatorsPerNominator
@@ -70,7 +64,8 @@ class RecommendationSettingsProvider(
     }
 
     fun defaultSelectCustomSettings() = RecommendationSettings(
-        filters = allFilters,
+        alwaysEnabledFilters = alwaysEnabledFilters,
+        customEnabledFilters = customizableFilters,
         sorting = APYSorting,
         postProcessors = allPostProcessors,
         limit = null

--- a/feature-staking-impl/src/main/java/jp/co/soramitsu/feature_staking_impl/presentation/validators/change/custom/select/SelectCustomValidatorsViewModel.kt
+++ b/feature-staking-impl/src/main/java/jp/co/soramitsu/feature_staking_impl/presentation/validators/change/custom/select/SelectCustomValidatorsViewModel.kt
@@ -108,7 +108,7 @@ class SelectCustomValidatorsViewModel(
     val fillWithRecommendedEnabled = selectedValidators.map { it.size < maxSelectedValidators }
         .share()
 
-    val clearFiltersEnabled = recommendationSettingsFlow.map { it.filters.isNotEmpty() || it.postProcessors.isNotEmpty() }
+    val clearFiltersEnabled = recommendationSettingsFlow.map { it.customEnabledFilters.isNotEmpty() || it.postProcessors.isNotEmpty() }
         .share()
 
     val deselectAllEnabled = selectedValidators.map { it.isNotEmpty() }

--- a/feature-staking-impl/src/main/java/jp/co/soramitsu/feature_staking_impl/presentation/validators/change/custom/settings/CustomValidatorsSettingsViewModel.kt
+++ b/feature-staking-impl/src/main/java/jp/co/soramitsu/feature_staking_impl/presentation/validators/change/custom/settings/CustomValidatorsSettingsViewModel.kt
@@ -89,7 +89,7 @@ class CustomValidatorsSettingsViewModel(
     }
 
     private fun initFromSettings(currentSettings: RecommendationSettings) {
-        currentSettings.filters.forEach {
+        currentSettings.customEnabledFilters.forEach {
             filtersEnabledMap[it::class.java]?.value = true
         }
 


### PR DESCRIPTION
Because at some point of time filters were divided into always enabled and customizable check allFilters.isNotEmpty() was always true since there were some always enabled  filters
Solution - include custom and always enabled filters separately into recommendation settings