### PR TITLE
Fix/max validators per nominator

### DIFF
--- a/common/src/main/java/jp/co/soramitsu/common/utils/FlowExt.kt
+++ b/common/src/main/java/jp/co/soramitsu/common/utils/FlowExt.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
@@ -139,4 +140,8 @@ inline fun <T> Flow<T>.observe(
 
 fun MutableStateFlow<Boolean>.toggle() {
     value = !value
+}
+
+fun <T> flowOf(producer: suspend () -> T) = flow {
+    emit(producer())
 }

--- a/common/src/main/java/jp/co/soramitsu/common/utils/KoltinExt.kt
+++ b/common/src/main/java/jp/co/soramitsu/common/utils/KoltinExt.kt
@@ -1,6 +1,8 @@
 package jp.co.soramitsu.common.utils
 
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.async
 import java.io.InputStream
 import java.math.BigDecimal
 import java.math.BigInteger
@@ -66,4 +68,8 @@ fun <T> List<T>.cycle(): Sequence<T> {
     var i = 0
 
     return generateSequence { this[i++ % this.size] }
+}
+
+inline fun <T> CoroutineScope.lazyAsync(crossinline producer: suspend () -> T) = lazy {
+    async { producer() }
 }

--- a/feature-staking-impl/src/main/java/jp/co/soramitsu/feature_staking_impl/data/repository/StakingConstantsRepository.kt
+++ b/feature-staking-impl/src/main/java/jp/co/soramitsu/feature_staking_impl/data/repository/StakingConstantsRepository.kt
@@ -6,8 +6,6 @@ import jp.co.soramitsu.common.utils.staking
 import jp.co.soramitsu.fearless_utils.runtime.RuntimeSnapshot
 import java.math.BigInteger
 
-private const val MAX_VALIDATORS_PER_NOMINATOR = 16
-
 class StakingConstantsRepository(
     private val runtimeProperty: SuspendableProperty<RuntimeSnapshot>,
 ) {
@@ -16,7 +14,7 @@ class StakingConstantsRepository(
 
     suspend fun lockupPeriodInEras(): BigInteger = getNumberConstant("BondingDuration")
 
-    fun maxValidatorsPerNominator(): Int = MAX_VALIDATORS_PER_NOMINATOR
+    suspend fun maxValidatorsPerNominator(): Int = getNumberConstant("MaxNominations").toInt()
 
     private suspend fun getNumberConstant(constantName: String): BigInteger {
         val runtime = runtimeProperty.get()

--- a/feature-staking-impl/src/main/java/jp/co/soramitsu/feature_staking_impl/di/StakingFeatureModule.kt
+++ b/feature-staking-impl/src/main/java/jp/co/soramitsu/feature_staking_impl/di/StakingFeatureModule.kt
@@ -191,7 +191,8 @@ class StakingFeatureModule {
     @FeatureScope
     fun provideRecommendationSettingsProviderFactory(
         stakingConstantsRepository: StakingConstantsRepository,
-    ) = RecommendationSettingsProviderFactory(stakingConstantsRepository)
+        computationalCache: ComputationalCache
+    ) = RecommendationSettingsProviderFactory(computationalCache, stakingConstantsRepository)
 
     @Provides
     @FeatureScope

--- a/feature-staking-impl/src/main/java/jp/co/soramitsu/feature_staking_impl/domain/StakingInteractor.kt
+++ b/feature-staking-impl/src/main/java/jp/co/soramitsu/feature_staking_impl/domain/StakingInteractor.kt
@@ -209,7 +209,7 @@ class StakingInteractor(
         return stakingRepository.getRewardDestination(accountStakingState)
     }
 
-    fun maxValidatorsPerNominator(): Int = stakingConstantsRepository.maxValidatorsPerNominator()
+    suspend fun maxValidatorsPerNominator(): Int = stakingConstantsRepository.maxValidatorsPerNominator()
 
     fun currentUnbondingsFlow(): Flow<List<Unbonding>> {
         return selectedAccountStakingStateFlow()

--- a/feature-staking-impl/src/main/java/jp/co/soramitsu/feature_staking_impl/domain/recommendations/settings/RecommendationSettingsProvider.kt
+++ b/feature-staking-impl/src/main/java/jp/co/soramitsu/feature_staking_impl/domain/recommendations/settings/RecommendationSettingsProvider.kt
@@ -11,7 +11,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 
 class RecommendationSettingsProvider(
     maximumRewardedNominators: Int,
-    val maximumValidatorsPerNominator: Int
+    private val maximumValidatorsPerNominator: Int
 ) {
 
     private val alwaysEnabledFilters = listOf(

--- a/feature-staking-impl/src/main/java/jp/co/soramitsu/feature_staking_impl/domain/recommendations/settings/RecommendationSettingsProviderFactory.kt
+++ b/feature-staking-impl/src/main/java/jp/co/soramitsu/feature_staking_impl/domain/recommendations/settings/RecommendationSettingsProviderFactory.kt
@@ -12,11 +12,11 @@ class RecommendationSettingsProviderFactory(
 ) {
 
     suspend fun create(lifecycle: Lifecycle): RecommendationSettingsProvider {
-       return computationalCache.useCache(SETTINGS_PROVIDER_KEY, lifecycle) {
-           RecommendationSettingsProvider(
-               maximumRewardedNominators = stakingConstantsRepository.maxRewardedNominatorPerValidator(),
-               maximumValidatorsPerNominator = stakingConstantsRepository.maxValidatorsPerNominator()
-           )
-       }
+        return computationalCache.useCache(SETTINGS_PROVIDER_KEY, lifecycle) {
+            RecommendationSettingsProvider(
+                maximumRewardedNominators = stakingConstantsRepository.maxRewardedNominatorPerValidator(),
+                maximumValidatorsPerNominator = stakingConstantsRepository.maxValidatorsPerNominator()
+            )
+        }
     }
 }

--- a/feature-staking-impl/src/main/java/jp/co/soramitsu/feature_staking_impl/domain/recommendations/settings/RecommendationSettingsProviderFactory.kt
+++ b/feature-staking-impl/src/main/java/jp/co/soramitsu/feature_staking_impl/domain/recommendations/settings/RecommendationSettingsProviderFactory.kt
@@ -1,22 +1,22 @@
 package jp.co.soramitsu.feature_staking_impl.domain.recommendations.settings
 
+import androidx.lifecycle.Lifecycle
+import jp.co.soramitsu.common.data.memory.ComputationalCache
 import jp.co.soramitsu.feature_staking_impl.data.repository.StakingConstantsRepository
 
+private const val SETTINGS_PROVIDER_KEY = "SETTINGS_PROVIDER_KEY"
+
 class RecommendationSettingsProviderFactory(
-    private val stakingConstantsRepository: StakingConstantsRepository,
+    private val computationalCache: ComputationalCache,
+    private val stakingConstantsRepository: StakingConstantsRepository
 ) {
 
-    private var instance: RecommendationSettingsProvider? = null
-
-    @Synchronized
-    suspend fun get(): RecommendationSettingsProvider {
-        if (instance != null) return instance!!
-
-        instance = RecommendationSettingsProvider(
-            maximumRewardedNominators = stakingConstantsRepository.maxRewardedNominatorPerValidator(),
-            maximumValidatorsPerNominator = stakingConstantsRepository.maxValidatorsPerNominator()
-        )
-
-        return instance!!
+    suspend fun create(lifecycle: Lifecycle): RecommendationSettingsProvider {
+       return computationalCache.useCache(SETTINGS_PROVIDER_KEY, lifecycle) {
+           RecommendationSettingsProvider(
+               maximumRewardedNominators = stakingConstantsRepository.maxRewardedNominatorPerValidator(),
+               maximumValidatorsPerNominator = stakingConstantsRepository.maxValidatorsPerNominator()
+           )
+       }
     }
 }

--- a/feature-staking-impl/src/main/java/jp/co/soramitsu/feature_staking_impl/presentation/confirm/ConfirmStakingViewModel.kt
+++ b/feature-staking-impl/src/main/java/jp/co/soramitsu/feature_staking_impl/presentation/confirm/ConfirmStakingViewModel.kt
@@ -105,7 +105,7 @@ class ConfirmStakingViewModel(
 
     val nominationsLiveData = liveData(Dispatchers.Default) {
         val selectedCount = payload.validators.size
-        val maxValidatorsPerNominator = recommendationSettingsProviderFactory.get().maximumValidatorsPerNominator
+        val maxValidatorsPerNominator = interactor.maxValidatorsPerNominator()
 
         emit(resourceManager.getString(R.string.staking_confirm_nominations, selectedCount, maxValidatorsPerNominator))
     }

--- a/feature-staking-impl/src/main/java/jp/co/soramitsu/feature_staking_impl/presentation/validators/change/custom/review/ReviewCustomValidatorsViewModel.kt
+++ b/feature-staking-impl/src/main/java/jp/co/soramitsu/feature_staking_impl/presentation/validators/change/custom/review/ReviewCustomValidatorsViewModel.kt
@@ -20,7 +20,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 

--- a/feature-staking-impl/src/main/java/jp/co/soramitsu/feature_staking_impl/presentation/validators/change/custom/review/ReviewCustomValidatorsViewModel.kt
+++ b/feature-staking-impl/src/main/java/jp/co/soramitsu/feature_staking_impl/presentation/validators/change/custom/review/ReviewCustomValidatorsViewModel.kt
@@ -3,6 +3,7 @@ package jp.co.soramitsu.feature_staking_impl.presentation.validators.change.cust
 import jp.co.soramitsu.common.address.AddressIconGenerator
 import jp.co.soramitsu.common.base.BaseViewModel
 import jp.co.soramitsu.common.resources.ResourceManager
+import jp.co.soramitsu.common.utils.flowOf
 import jp.co.soramitsu.common.utils.inBackground
 import jp.co.soramitsu.feature_staking_impl.R
 import jp.co.soramitsu.feature_staking_impl.domain.StakingInteractor
@@ -43,8 +44,8 @@ class ReviewCustomValidatorsViewModel(
     private val currentTokenFlow = tokenUseCase.currentTokenFlow()
         .share()
 
-    private val maxValidatorsPerNominatorFlow = flow {
-        emit(interactor.maxValidatorsPerNominator())
+    private val maxValidatorsPerNominatorFlow = flowOf {
+        interactor.maxValidatorsPerNominator()
     }.share()
 
     val selectionStateFlow = combine(

--- a/feature-staking-impl/src/main/java/jp/co/soramitsu/feature_staking_impl/presentation/validators/change/custom/select/SelectCustomValidatorsViewModel.kt
+++ b/feature-staking-impl/src/main/java/jp/co/soramitsu/feature_staking_impl/presentation/validators/change/custom/select/SelectCustomValidatorsViewModel.kt
@@ -7,6 +7,8 @@ import jp.co.soramitsu.common.base.BaseViewModel
 import jp.co.soramitsu.common.resources.ResourceManager
 import jp.co.soramitsu.common.utils.flowOf
 import jp.co.soramitsu.common.utils.inBackground
+import jp.co.soramitsu.common.utils.invoke
+import jp.co.soramitsu.common.utils.lazyAsync
 import jp.co.soramitsu.common.utils.toggle
 import jp.co.soramitsu.feature_staking_api.domain.model.Validator
 import jp.co.soramitsu.feature_staking_impl.R
@@ -26,7 +28,6 @@ import jp.co.soramitsu.feature_staking_impl.presentation.validators.change.custo
 import jp.co.soramitsu.feature_staking_impl.presentation.validators.change.setCustomValidators
 import jp.co.soramitsu.feature_wallet_api.domain.TokenUseCase
 import jp.co.soramitsu.feature_wallet_api.domain.model.Token
-import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.emitAll
@@ -49,8 +50,12 @@ class SelectCustomValidatorsViewModel(
     private val tokenUseCase: TokenUseCase,
 ) : BaseViewModel() {
 
-    private val validatorRecommendator by lazy {
-        async { validatorRecommendatorFactory.create(router.currentStackEntryLifecycle) }
+    private val validatorRecommendator by lazyAsync {
+        validatorRecommendatorFactory.create(router.currentStackEntryLifecycle)
+    }
+
+    private val recommendationSettingsProvider by lazyAsync {
+        recommendationSettingsProviderFactory.create(router.currentStackEntryLifecycle)
     }
 
     private val recommendationSettingsFlow = flow {
@@ -218,6 +223,4 @@ class SelectCustomValidatorsViewModel(
             selectedValidators.value = mutation(selectedValidators.value)
         }
     }
-
-    private suspend fun recommendationSettingsProvider() = recommendationSettingsProviderFactory.get()
 }

--- a/feature-staking-impl/src/main/java/jp/co/soramitsu/feature_staking_impl/presentation/validators/change/custom/settings/CustomValidatorsSettingsViewModel.kt
+++ b/feature-staking-impl/src/main/java/jp/co/soramitsu/feature_staking_impl/presentation/validators/change/custom/settings/CustomValidatorsSettingsViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.viewModelScope
 import jp.co.soramitsu.common.base.BaseViewModel
 import jp.co.soramitsu.common.utils.inBackground
 import jp.co.soramitsu.common.utils.invoke
+import jp.co.soramitsu.common.utils.lazyAsync
 import jp.co.soramitsu.common.utils.reversed
 import jp.co.soramitsu.feature_staking_impl.R
 import jp.co.soramitsu.feature_staking_impl.domain.recommendations.settings.RecommendationSettings
@@ -39,8 +40,8 @@ class CustomValidatorsSettingsViewModel(
     private val tokenUseCase: TokenUseCase
 ) : BaseViewModel() {
 
-    private val recommendationSettingsProvider by lazy {
-        async { recommendationSettingsProviderFactory.get() }
+    private val recommendationSettingsProvider by lazyAsync {
+        recommendationSettingsProviderFactory.create(router.currentStackEntryLifecycle)
     }
 
     val selectedSortingIdFlow = MutableStateFlow(R.id.customValidatorSettingsSortAPY)

--- a/feature-staking-impl/src/main/java/jp/co/soramitsu/feature_staking_impl/presentation/validators/change/custom/settings/CustomValidatorsSettingsViewModel.kt
+++ b/feature-staking-impl/src/main/java/jp/co/soramitsu/feature_staking_impl/presentation/validators/change/custom/settings/CustomValidatorsSettingsViewModel.kt
@@ -18,7 +18,6 @@ import jp.co.soramitsu.feature_staking_impl.domain.recommendations.settings.sort
 import jp.co.soramitsu.feature_staking_impl.domain.recommendations.settings.sortings.ValidatorOwnStakeSorting
 import jp.co.soramitsu.feature_staking_impl.presentation.StakingRouter
 import jp.co.soramitsu.feature_wallet_api.domain.TokenUseCase
-import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first

--- a/feature-staking-impl/src/main/java/jp/co/soramitsu/feature_staking_impl/presentation/validators/change/recommended/RecommendedValidatorsViewModel.kt
+++ b/feature-staking-impl/src/main/java/jp/co/soramitsu/feature_staking_impl/presentation/validators/change/recommended/RecommendedValidatorsViewModel.kt
@@ -5,6 +5,8 @@ import jp.co.soramitsu.common.address.AddressIconGenerator
 import jp.co.soramitsu.common.base.BaseViewModel
 import jp.co.soramitsu.common.resources.ResourceManager
 import jp.co.soramitsu.common.utils.inBackground
+import jp.co.soramitsu.common.utils.invoke
+import jp.co.soramitsu.common.utils.lazyAsync
 import jp.co.soramitsu.feature_staking_api.domain.model.Validator
 import jp.co.soramitsu.feature_staking_impl.R
 import jp.co.soramitsu.feature_staking_impl.domain.StakingInteractor
@@ -36,6 +38,10 @@ class RecommendedValidatorsViewModel(
     private val sharedStateSetup: SetupStakingSharedState,
     private val tokenUseCase: TokenUseCase,
 ) : BaseViewModel() {
+
+    private val recommendedSettings by lazyAsync {
+        recommendationSettingsProviderFactory.create(router.currentStackEntryLifecycle).defaultSettings()
+    }
 
     private val recommendedValidators = flow {
         val validatorRecommendator = validatorRecommendatorFactory.create(router.currentStackEntryLifecycle)
@@ -79,10 +85,6 @@ class RecommendedValidatorsViewModel(
         return validators.map {
             mapValidatorToValidatorModel(it, addressIconGenerator, token)
         }
-    }
-
-    private suspend fun recommendedSettings(): RecommendationSettings {
-        return recommendationSettingsProviderFactory.get().defaultSettings()
     }
 
     private fun retractRecommended() = sharedStateSetup.mutate {

--- a/feature-staking-impl/src/main/java/jp/co/soramitsu/feature_staking_impl/presentation/validators/change/recommended/RecommendedValidatorsViewModel.kt
+++ b/feature-staking-impl/src/main/java/jp/co/soramitsu/feature_staking_impl/presentation/validators/change/recommended/RecommendedValidatorsViewModel.kt
@@ -11,7 +11,6 @@ import jp.co.soramitsu.feature_staking_api.domain.model.Validator
 import jp.co.soramitsu.feature_staking_impl.R
 import jp.co.soramitsu.feature_staking_impl.domain.StakingInteractor
 import jp.co.soramitsu.feature_staking_impl.domain.recommendations.ValidatorRecommendatorFactory
-import jp.co.soramitsu.feature_staking_impl.domain.recommendations.settings.RecommendationSettings
 import jp.co.soramitsu.feature_staking_impl.domain.recommendations.settings.RecommendationSettingsProviderFactory
 import jp.co.soramitsu.feature_staking_impl.presentation.StakingRouter
 import jp.co.soramitsu.feature_staking_impl.presentation.common.SetupStakingProcess.ReadyToSubmit

--- a/feature-staking-impl/src/main/java/jp/co/soramitsu/feature_staking_impl/presentation/validators/current/CurrentValidatorsViewModel.kt
+++ b/feature-staking-impl/src/main/java/jp/co/soramitsu/feature_staking_impl/presentation/validators/current/CurrentValidatorsViewModel.kt
@@ -122,12 +122,8 @@ class CurrentValidatorsViewModel(
 
             val currentValidators = flattenCurrentValidators.first().map(NominatedValidator::validator)
 
-            val newState = if (currentValidators.isEmpty()) {
-                currentState.changeValidatorsFlow()
-            } else {
-                currentState.changeValidatorsFlow()
+            val newState = currentState.changeValidatorsFlow()
                     .next(currentValidators, SelectionMethod.CUSTOM)
-            }
 
             setupStakingSharedState.set(newState)
 

--- a/feature-staking-impl/src/main/java/jp/co/soramitsu/feature_staking_impl/presentation/validators/current/CurrentValidatorsViewModel.kt
+++ b/feature-staking-impl/src/main/java/jp/co/soramitsu/feature_staking_impl/presentation/validators/current/CurrentValidatorsViewModel.kt
@@ -123,7 +123,7 @@ class CurrentValidatorsViewModel(
             val currentValidators = flattenCurrentValidators.first().map(NominatedValidator::validator)
 
             val newState = currentState.changeValidatorsFlow()
-                    .next(currentValidators, SelectionMethod.CUSTOM)
+                .next(currentValidators, SelectionMethod.CUSTOM)
 
             setupStakingSharedState.set(newState)
 


### PR DESCRIPTION
* Use runtime constant for max nominations
* Do not show 'update your list' for empty validator list
* Fix - runtime constants in settings provider are not invalidated after network/runtime change

![image](https://user-images.githubusercontent.com/70131744/126439919-a87437fc-9fb5-449c-b392-c5ec7a7fb51d.png)
