### PR TITLE
Fix/min bond

### DIFF
--- a/feature-staking-impl/src/main/java/jp/co/soramitsu/feature_staking_impl/di/StakingFeatureModule.kt
+++ b/feature-staking-impl/src/main/java/jp/co/soramitsu/feature_staking_impl/di/StakingFeatureModule.kt
@@ -135,7 +135,6 @@ class StakingFeatureModule {
         stakingRepository: StakingRepository,
         stakingRewardsRepository: StakingRewardsRepository,
         stakingConstantsRepository: StakingConstantsRepository,
-        walletConstants: WalletConstants,
         identityRepository: IdentityRepository,
         payoutRepository: PayoutRepository,
     ) = StakingInteractor(
@@ -145,7 +144,6 @@ class StakingFeatureModule {
         stakingRewardsRepository,
         stakingConstantsRepository,
         identityRepository,
-        walletConstants,
         payoutRepository
     )
 

--- a/feature-staking-impl/src/main/java/jp/co/soramitsu/feature_staking_impl/domain/StakingInteractor.kt
+++ b/feature-staking-impl/src/main/java/jp/co/soramitsu/feature_staking_impl/domain/StakingInteractor.kt
@@ -30,7 +30,6 @@ import jp.co.soramitsu.feature_staking_impl.domain.model.StakeSummary
 import jp.co.soramitsu.feature_staking_impl.domain.model.StashNoneStatus
 import jp.co.soramitsu.feature_staking_impl.domain.model.Unbonding
 import jp.co.soramitsu.feature_staking_impl.domain.model.ValidatorStatus
-import jp.co.soramitsu.feature_wallet_api.domain.interfaces.WalletConstants
 import jp.co.soramitsu.feature_wallet_api.domain.interfaces.WalletRepository
 import jp.co.soramitsu.feature_wallet_api.domain.model.Asset
 import jp.co.soramitsu.feature_wallet_api.domain.model.Token
@@ -62,7 +61,6 @@ class StakingInteractor(
     private val stakingRewardsRepository: StakingRewardsRepository,
     private val stakingConstantsRepository: StakingConstantsRepository,
     private val identityRepository: IdentityRepository,
-    private val walletConstants: WalletConstants,
     private val payoutRepository: PayoutRepository,
 ) {
 
@@ -128,7 +126,6 @@ class StakingInteractor(
     suspend fun observeNominatorSummary(
         nominatorState: StakingState.Stash.Nominator,
     ): Flow<StakeSummary<NominatorStatus>> = observeStakeSummary(nominatorState) {
-        val existentialDeposit = walletConstants.existentialDeposit()
         val eraStakers = it.eraStakers.values
 
         when {
@@ -137,7 +134,7 @@ class StakingInteractor(
 
             else -> {
                 val inactiveReason = when {
-                    it.asset.bondedInPlanks < minimumStake(eraStakers, existentialDeposit) -> NominatorStatus.Inactive.Reason.MIN_STAKE
+                    it.asset.bondedInPlanks < minimumStake(eraStakers, stakingRepository.minimumNominatorBond()) -> NominatorStatus.Inactive.Reason.MIN_STAKE
                     else -> NominatorStatus.Inactive.Reason.NO_ACTIVE_VALIDATOR
                 }
 

--- a/feature-staking-impl/src/main/java/jp/co/soramitsu/feature_staking_impl/domain/StakingInteractor.kt
+++ b/feature-staking-impl/src/main/java/jp/co/soramitsu/feature_staking_impl/domain/StakingInteractor.kt
@@ -154,7 +154,7 @@ class StakingInteractor(
 
             NetworkInfo(
                 lockupPeriodInDays = lockupPeriod,
-                minimumStake = minimumStake(exposures, walletConstants.existentialDeposit()),
+                minimumStake = minimumStake(exposures, stakingRepository.minimumNominatorBond()),
                 totalStake = totalStake(exposures),
                 nominatorsCount = activeNominators(exposures),
             )

--- a/feature-staking-impl/src/main/java/jp/co/soramitsu/feature_staking_impl/domain/StakingInteractorExt.kt
+++ b/feature-staking-impl/src/main/java/jp/co/soramitsu/feature_staking_impl/domain/StakingInteractorExt.kt
@@ -41,7 +41,7 @@ fun Exposure.willAccountBeRewarded(
 
 fun minimumStake(
     exposures: Collection<Exposure>,
-    existentialDeposit: BigInteger,
+    minimumNominatorBond: BigInteger,
 ): BigInteger {
 
     val stakeByNominator = exposures
@@ -55,5 +55,5 @@ fun minimumStake(
             acc
         }
 
-    return stakeByNominator.values.minOrNull()!!.coerceAtLeast(existentialDeposit)
+    return stakeByNominator.values.minOrNull()!!.coerceAtLeast(minimumNominatorBond)
 }


### PR DESCRIPTION
Fix - min stake does not take MinNominatorBond into account on staking screen:
* Min stake in Network widget
* Inactive description in Stake widget

![image](https://user-images.githubusercontent.com/70131744/129745318-bfd189de-d808-41e8-9f21-539d88c9fe89.png)

