### PR TITLE
V2.0/updaters

### DIFF
--- a/app/src/main/java/jp/co/soramitsu/app/root/di/RootDependencies.kt
+++ b/app/src/main/java/jp/co/soramitsu/app/root/di/RootDependencies.kt
@@ -3,12 +3,11 @@ package jp.co.soramitsu.app.root.di
 import jp.co.soramitsu.common.data.network.AppLinksProvider
 import jp.co.soramitsu.common.mixin.api.NetworkStateMixin
 import jp.co.soramitsu.common.resources.ResourceManager
+import jp.co.soramitsu.core.updater.UpdateSystem
 import jp.co.soramitsu.feature_account_api.domain.interfaces.AccountRepository
-import jp.co.soramitsu.feature_crowdloan_api.data.network.blockhain.updaters.CrowdloanUpdaters
 import jp.co.soramitsu.feature_crowdloan_api.data.repository.CrowdloanRepository
-import jp.co.soramitsu.feature_staking_api.di.StakingUpdaters
 import jp.co.soramitsu.feature_staking_api.domain.api.StakingRepository
-import jp.co.soramitsu.feature_wallet_api.di.WalletUpdaters
+import jp.co.soramitsu.feature_wallet_api.di.Wallet
 import jp.co.soramitsu.feature_wallet_api.domain.interfaces.WalletRepository
 import jp.co.soramitsu.feature_wallet_api.domain.model.BuyTokenRegistry
 import jp.co.soramitsu.runtime.multiNetwork.ChainRegistry
@@ -33,11 +32,8 @@ interface RootDependencies {
 
     fun resourceManager(): ResourceManager
 
-    fun walletUpdaters(): WalletUpdaters
-
-    fun stakingUpdaters(): StakingUpdaters
-
-    fun crowdloanUpdaters(): CrowdloanUpdaters
+    @Wallet
+    fun walletUpdateSystem(): UpdateSystem
 
     fun stakingRepository(): StakingRepository
 

--- a/app/src/main/java/jp/co/soramitsu/app/root/di/RootFeatureModule.kt
+++ b/app/src/main/java/jp/co/soramitsu/app/root/di/RootFeatureModule.kt
@@ -3,43 +3,22 @@ package jp.co.soramitsu.app.root.di
 import dagger.Module
 import dagger.Provides
 import jp.co.soramitsu.app.root.domain.RootInteractor
-import jp.co.soramitsu.app.root.domain.UpdateSystem
 import jp.co.soramitsu.common.di.scope.FeatureScope
-import jp.co.soramitsu.feature_crowdloan_api.data.network.blockhain.updaters.CrowdloanUpdaters
-import jp.co.soramitsu.feature_staking_api.di.StakingUpdaters
-import jp.co.soramitsu.feature_wallet_api.di.WalletUpdaters
+import jp.co.soramitsu.core.updater.UpdateSystem
+import jp.co.soramitsu.feature_wallet_api.di.Wallet
 import jp.co.soramitsu.feature_wallet_api.domain.interfaces.WalletRepository
-import jp.co.soramitsu.runtime.multiNetwork.ChainRegistry
 
 @Module
 class RootFeatureModule {
 
     @Provides
     @FeatureScope
-    fun provideUpdateSystem(
-        walletUpdaters: WalletUpdaters,
-        stakingUpdaters: StakingUpdaters,
-        crowdloanUpdaters: CrowdloanUpdaters,
-        chainRegistry: ChainRegistry,
-    ): UpdateSystem {
-        return UpdateSystem(
-            updaters = listOf(
-                *walletUpdaters.updaters,
-                *stakingUpdaters.updaters,
-                *crowdloanUpdaters.updaters
-            ),
-            chainRegistry
-        )
-    }
-
-    @Provides
-    @FeatureScope
     fun provideRootInteractor(
-        updateSystem: UpdateSystem,
-        walletRepository: WalletRepository
+        walletRepository: WalletRepository,
+        @Wallet walletUpdateSystem: UpdateSystem,
     ): RootInteractor {
         return RootInteractor(
-            updateSystem,
+            walletUpdateSystem,
             walletRepository
         )
     }

--- a/app/src/main/java/jp/co/soramitsu/app/root/domain/RootInteractor.kt
+++ b/app/src/main/java/jp/co/soramitsu/app/root/domain/RootInteractor.kt
@@ -1,5 +1,6 @@
 package jp.co.soramitsu.app.root.domain
 
+import jp.co.soramitsu.core.updater.UpdateSystem
 import jp.co.soramitsu.core.updater.Updater
 import jp.co.soramitsu.feature_wallet_api.domain.interfaces.WalletRepository
 import jp.co.soramitsu.feature_wallet_impl.data.buyToken.ExternalProvider
@@ -11,7 +12,7 @@ class RootInteractor(
     private val walletRepository: WalletRepository,
 ) {
 
-    fun runUpdateSystem(): Flow<Updater.SideEffect> = updateSystem.start()
+    fun runBalancesUpdate(): Flow<Updater.SideEffect> = updateSystem.start()
 
     fun isBuyProviderRedirectLink(link: String) = ExternalProvider.REDIRECT_URL_BASE in link
 

--- a/app/src/main/java/jp/co/soramitsu/app/root/presentation/RootViewModel.kt
+++ b/app/src/main/java/jp/co/soramitsu/app/root/presentation/RootViewModel.kt
@@ -25,7 +25,7 @@ class RootViewModel(
     private var willBeClearedForLanguageChange = false
 
     init {
-        interactor.runUpdateSystem()
+        interactor.runBalancesUpdate()
             .onEach { handleUpdatesSideEffect(it) }
             .launchIn(this)
 

--- a/common/src/main/java/jp/co/soramitsu/common/data/network/StorageSubscriptionBuilder.kt
+++ b/common/src/main/java/jp/co/soramitsu/common/data/network/StorageSubscriptionBuilder.kt
@@ -10,7 +10,7 @@ import kotlinx.coroutines.flow.map
 
 class StorageSubscriptionBuilder(
     override val socketService: SocketService,
-    val proxy: StorageSubscriptionMultiplexer.Builder
+    private val proxy: StorageSubscriptionMultiplexer.Builder
 ) : SubscriptionBuilder {
 
     companion object {
@@ -26,4 +26,6 @@ class StorageSubscriptionBuilder(
         return proxy.subscribe(key)
             .map { StorageChange(it.block, it.key, it.value) }
     }
+
+    fun build() = proxy.build()
 }

--- a/core-api/src/main/java/jp/co/soramitsu/core/updater/Updater.kt
+++ b/core-api/src/main/java/jp/co/soramitsu/core/updater/Updater.kt
@@ -15,7 +15,7 @@ interface SideEffectScope {
 
 interface UpdateScope {
 
-     fun invalidationFlow(): Flow<Any>
+    fun invalidationFlow(): Flow<Any>
 }
 
 object GlobalScope : UpdateScope {

--- a/core-api/src/main/java/jp/co/soramitsu/core/updater/Updater.kt
+++ b/core-api/src/main/java/jp/co/soramitsu/core/updater/Updater.kt
@@ -44,3 +44,8 @@ interface Updater : SideEffectScope {
 
     interface SideEffect
 }
+
+interface UpdateSystem {
+
+    fun start(): Flow<Updater.SideEffect>
+}

--- a/core-api/src/main/java/jp/co/soramitsu/core/updater/Updater.kt
+++ b/core-api/src/main/java/jp/co/soramitsu/core/updater/Updater.kt
@@ -15,12 +15,12 @@ interface SideEffectScope {
 
 interface UpdateScope {
 
-    suspend fun invalidationFlow(): Flow<Any>
+     fun invalidationFlow(): Flow<Any>
 }
 
 object GlobalScope : UpdateScope {
 
-    override suspend fun invalidationFlow() = flowOf(Unit)
+    override fun invalidationFlow() = flowOf(Unit)
 }
 
 interface GlobalScopeUpdater : Updater {

--- a/core-db/src/main/java/jp/co/soramitsu/core_db/dao/AssetDao.kt
+++ b/core-db/src/main/java/jp/co/soramitsu/core_db/dao/AssetDao.kt
@@ -34,7 +34,7 @@ abstract class AssetDao : AssetReadOnlyCache {
 
     @Query(
         """
-       select * from assets as a inner join tokens as t on a.tokenSymbol = t.symbol WHERE a.metaId = :metaId
+       select * from assets as a inner join tokens as t on a.tokenSymbol = t.symbol WHERE a.metaId = :metaId ORDER BY a.tokenSymbol, a.chainId
     """
     )
     abstract override fun observeAssets(metaId: Long): Flow<List<AssetWithToken>>

--- a/core-db/src/main/java/jp/co/soramitsu/core_db/dao/AssetDao.kt
+++ b/core-db/src/main/java/jp/co/soramitsu/core_db/dao/AssetDao.kt
@@ -27,6 +27,8 @@ interface AssetReadOnlyCache {
     fun observeAsset(accountId: AccountId, chainId: String, symbol: String): Flow<AssetWithToken>
 
     suspend fun getAsset(accountId: AccountId, chainId: String, symbol: String): AssetWithToken?
+
+    suspend fun getAsset(metaId: Long, chainId: String, symbol: String): AssetWithToken?
 }
 
 @Dao
@@ -47,6 +49,9 @@ abstract class AssetDao : AssetReadOnlyCache {
 
     @Query(RETRIEVE_ASSET_SQL_ACCOUNT_ID)
     abstract override suspend fun getAsset(accountId: AccountId, chainId: String, symbol: String): AssetWithToken?
+
+    @Query(RETRIEVE_ASSET_SQL_META_ID)
+    abstract override suspend fun getAsset(metaId: Long, chainId: String, symbol: String): AssetWithToken?
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     abstract suspend fun insertAsset(asset: AssetLocal)

--- a/core-db/src/main/java/jp/co/soramitsu/core_db/dao/TokenDao.kt
+++ b/core-db/src/main/java/jp/co/soramitsu/core_db/dao/TokenDao.kt
@@ -21,4 +21,9 @@ abstract class TokenDao {
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     abstract suspend fun insertToken(token: TokenLocal)
+
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    abstract suspend fun insertTokenOrIgnore(token: TokenLocal)
+
+    suspend fun ensureToken(symbol: String) = insertTokenOrIgnore(TokenLocal.createEmpty(symbol))
 }

--- a/feature-account-api/src/main/java/jp/co/soramitsu/feature_account_api/domain/updaters/AccountUpdateScope.kt
+++ b/feature-account-api/src/main/java/jp/co/soramitsu/feature_account_api/domain/updaters/AccountUpdateScope.kt
@@ -2,13 +2,14 @@ package jp.co.soramitsu.feature_account_api.domain.updaters
 
 import jp.co.soramitsu.core.updater.UpdateScope
 import jp.co.soramitsu.feature_account_api.domain.interfaces.AccountRepository
+import jp.co.soramitsu.feature_account_api.domain.model.MetaAccount
 import kotlinx.coroutines.flow.Flow
 
 class AccountUpdateScope(
     private val accountRepository: AccountRepository
 ) : UpdateScope {
 
-    override suspend fun invalidationFlow(): Flow<Any> {
+    override fun invalidationFlow(): Flow<MetaAccount> {
         return accountRepository.selectedMetaAccountFlow()
     }
 

--- a/feature-crowdloan-api/build.gradle
+++ b/feature-crowdloan-api/build.gradle
@@ -29,6 +29,8 @@ dependencies {
     implementation project(':runtime')
     implementation project(":common")
 
+    implementation daggerDep
+
     implementation fearlessLibDep
 
     implementation androidDep

--- a/feature-crowdloan-api/src/main/java/jp/co/soramitsu/feature_crowdloan_api/data/network/blockhain/updaters/CrowdloanUpdaters.kt
+++ b/feature-crowdloan-api/src/main/java/jp/co/soramitsu/feature_crowdloan_api/data/network/blockhain/updaters/CrowdloanUpdaters.kt
@@ -1,5 +1,0 @@
-package jp.co.soramitsu.feature_crowdloan_api.data.network.blockhain.updaters
-
-import jp.co.soramitsu.core.updater.Updater
-
-class CrowdloanUpdaters(val updaters: Array<Updater>)

--- a/feature-crowdloan-api/src/main/java/jp/co/soramitsu/feature_crowdloan_api/di/Crowdloan.kt
+++ b/feature-crowdloan-api/src/main/java/jp/co/soramitsu/feature_crowdloan_api/di/Crowdloan.kt
@@ -1,0 +1,7 @@
+package jp.co.soramitsu.feature_crowdloan_api.di
+
+import javax.inject.Qualifier
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class Crowdloan

--- a/feature-crowdloan-api/src/main/java/jp/co/soramitsu/feature_crowdloan_api/di/CrowdloanFeatureApi.kt
+++ b/feature-crowdloan-api/src/main/java/jp/co/soramitsu/feature_crowdloan_api/di/CrowdloanFeatureApi.kt
@@ -1,11 +1,8 @@
 package jp.co.soramitsu.feature_crowdloan_api.di
 
-import jp.co.soramitsu.feature_crowdloan_api.data.network.blockhain.updaters.CrowdloanUpdaters
 import jp.co.soramitsu.feature_crowdloan_api.data.repository.CrowdloanRepository
 
 interface CrowdloanFeatureApi {
 
     fun repository(): CrowdloanRepository
-
-    fun updaters(): CrowdloanUpdaters
 }

--- a/feature-crowdloan-impl/src/main/java/jp/co/soramitsu/feature_crowdloan_impl/di/CrowdloanUpdatersModule.kt
+++ b/feature-crowdloan-impl/src/main/java/jp/co/soramitsu/feature_crowdloan_impl/di/CrowdloanUpdatersModule.kt
@@ -4,10 +4,11 @@ import dagger.Module
 import dagger.Provides
 import jp.co.soramitsu.common.di.scope.FeatureScope
 import jp.co.soramitsu.core.storage.StorageCache
-import jp.co.soramitsu.feature_crowdloan_api.data.network.blockhain.updaters.CrowdloanUpdaters
+import jp.co.soramitsu.core.updater.UpdateSystem
 import jp.co.soramitsu.feature_crowdloan_impl.data.CrowdloanSharedState
 import jp.co.soramitsu.feature_crowdloan_impl.data.network.blockhain.updaters.BlockNumberUpdater
 import jp.co.soramitsu.runtime.multiNetwork.ChainRegistry
+import jp.co.soramitsu.runtime.network.updaters.SingleChainUpdateSystem
 
 @Module
 class CrowdloanUpdatersModule {
@@ -22,11 +23,15 @@ class CrowdloanUpdatersModule {
 
     @Provides
     @FeatureScope
-    fun provideCrowdloanUpdaters(
+    fun provideCrowdloanUpdateSystem(
+        chainRegistry: ChainRegistry,
+        crowdloanSharedState: CrowdloanSharedState,
         blockNumberUpdater: BlockNumberUpdater,
-    ) = CrowdloanUpdaters(
-        arrayOf(
+    ): UpdateSystem = SingleChainUpdateSystem(
+        updaters = listOf(
             blockNumberUpdater
-        )
+        ),
+        chainRegistry = chainRegistry,
+        singleAssetSharedState = crowdloanSharedState
     )
 }

--- a/feature-crowdloan-impl/src/main/java/jp/co/soramitsu/feature_crowdloan_impl/presentation/main/CrowdloanViewModel.kt
+++ b/feature-crowdloan-impl/src/main/java/jp/co/soramitsu/feature_crowdloan_impl/presentation/main/CrowdloanViewModel.kt
@@ -9,6 +9,7 @@ import jp.co.soramitsu.common.resources.formatTimeLeft
 import jp.co.soramitsu.common.utils.format
 import jp.co.soramitsu.common.utils.inBackground
 import jp.co.soramitsu.common.utils.withLoading
+import jp.co.soramitsu.core.updater.UpdateSystem
 import jp.co.soramitsu.feature_crowdloan_api.data.network.blockhain.binding.ParaId
 import jp.co.soramitsu.feature_crowdloan_impl.R
 import jp.co.soramitsu.feature_crowdloan_impl.data.CrowdloanSharedState
@@ -28,6 +29,7 @@ import jp.co.soramitsu.runtime.multiNetwork.chain.model.Chain
 import jp.co.soramitsu.runtime.state.chain
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import kotlin.reflect.KClass
@@ -40,7 +42,8 @@ class CrowdloanViewModel(
     private val iconGenerator: AddressIconGenerator,
     private val resourceManager: ResourceManager,
     private val crowdloanSharedState: CrowdloanSharedState,
-    private val router: CrowdloanRouter
+    private val router: CrowdloanRouter,
+    private val crowdloanUpdateSystem: UpdateSystem
 ) : BaseViewModel() {
 
     private val assetFlow = assetUseCase.currentAssetFlow()
@@ -70,6 +73,11 @@ class CrowdloanViewModel(
         .withLoading()
         .inBackground()
         .share()
+
+    init {
+        crowdloanUpdateSystem.start()
+            .launchIn(this)
+    }
 
     private fun mapCrowdloanStatusToUi(statusClass: KClass<out Crowdloan.State>, statusCount: Int): CrowdloanStatusModel {
         return when (statusClass) {

--- a/feature-crowdloan-impl/src/main/java/jp/co/soramitsu/feature_crowdloan_impl/presentation/main/di/CrowdloanModule.kt
+++ b/feature-crowdloan-impl/src/main/java/jp/co/soramitsu/feature_crowdloan_impl/presentation/main/di/CrowdloanModule.kt
@@ -10,6 +10,7 @@ import jp.co.soramitsu.common.address.AddressIconGenerator
 import jp.co.soramitsu.common.di.viewmodel.ViewModelKey
 import jp.co.soramitsu.common.di.viewmodel.ViewModelModule
 import jp.co.soramitsu.common.resources.ResourceManager
+import jp.co.soramitsu.core.updater.UpdateSystem
 import jp.co.soramitsu.feature_crowdloan_impl.data.CrowdloanSharedState
 import jp.co.soramitsu.feature_crowdloan_impl.domain.main.CrowdloanInteractor
 import jp.co.soramitsu.feature_crowdloan_impl.presentation.CrowdloanRouter
@@ -28,7 +29,8 @@ class CrowdloanModule {
         resourceManager: ResourceManager,
         iconGenerator: AddressIconGenerator,
         crowdloanSharedState: CrowdloanSharedState,
-        router: CrowdloanRouter
+        router: CrowdloanRouter,
+        crowdloanUpdateSystem: UpdateSystem
     ): ViewModel {
         return CrowdloanViewModel(
             interactor,
@@ -36,7 +38,8 @@ class CrowdloanModule {
             iconGenerator,
             resourceManager,
             crowdloanSharedState,
-            router
+            router,
+            crowdloanUpdateSystem
         )
     }
 

--- a/feature-staking-api/build.gradle
+++ b/feature-staking-api/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     implementation coroutinesDep
 
     implementation fearlessLibDep
+    implementation daggerDep
 
     implementation project(':runtime')
     implementation project(':common')

--- a/feature-staking-api/src/main/java/jp/co/soramitsu/feature_staking_api/di/Staking.kt
+++ b/feature-staking-api/src/main/java/jp/co/soramitsu/feature_staking_api/di/Staking.kt
@@ -1,0 +1,7 @@
+package jp.co.soramitsu.feature_staking_api.di
+
+import javax.inject.Qualifier
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class Staking

--- a/feature-staking-api/src/main/java/jp/co/soramitsu/feature_staking_api/di/StakingFeatureApi.kt
+++ b/feature-staking-api/src/main/java/jp/co/soramitsu/feature_staking_api/di/StakingFeatureApi.kt
@@ -5,6 +5,4 @@ import jp.co.soramitsu.feature_staking_api.domain.api.StakingRepository
 interface StakingFeatureApi {
 
     fun repository(): StakingRepository
-
-    fun provideUpdaters(): StakingUpdaters
 }

--- a/feature-staking-api/src/main/java/jp/co/soramitsu/feature_staking_api/di/StakingUpdaters.kt
+++ b/feature-staking-api/src/main/java/jp/co/soramitsu/feature_staking_api/di/StakingUpdaters.kt
@@ -1,5 +1,0 @@
-package jp.co.soramitsu.feature_staking_api.di
-
-import jp.co.soramitsu.core.updater.Updater
-
-class StakingUpdaters(val updaters: Array<Updater>)

--- a/feature-staking-impl/src/main/java/jp/co/soramitsu/feature_staking_impl/data/network/blockhain/updaters/scope/AccountStakingScope.kt
+++ b/feature-staking-impl/src/main/java/jp/co/soramitsu/feature_staking_impl/data/network/blockhain/updaters/scope/AccountStakingScope.kt
@@ -16,7 +16,7 @@ class AccountStakingScope(
     private val sharedStakingState: StakingSharedState
 ) : UpdateScope {
 
-    override suspend fun invalidationFlow(): Flow<Any> {
+    override fun invalidationFlow(): Flow<Any> {
         return combineTransform(
             sharedStakingState.selectedAsset,
             accountRepository.selectedMetaAccountFlow()

--- a/feature-staking-impl/src/main/java/jp/co/soramitsu/feature_staking_impl/di/StakingUpdatersModule.kt
+++ b/feature-staking-impl/src/main/java/jp/co/soramitsu/feature_staking_impl/di/StakingUpdatersModule.kt
@@ -5,10 +5,10 @@ import dagger.Provides
 import jp.co.soramitsu.common.data.network.rpc.BulkRetriever
 import jp.co.soramitsu.common.di.scope.FeatureScope
 import jp.co.soramitsu.core.storage.StorageCache
+import jp.co.soramitsu.core.updater.UpdateSystem
 import jp.co.soramitsu.core_db.dao.AccountStakingDao
 import jp.co.soramitsu.feature_account_api.domain.interfaces.AccountRepository
 import jp.co.soramitsu.feature_account_api.domain.updaters.AccountUpdateScope
-import jp.co.soramitsu.feature_staking_api.di.StakingUpdaters
 import jp.co.soramitsu.feature_staking_api.domain.api.StakingRepository
 import jp.co.soramitsu.feature_staking_impl.data.StakingSharedState
 import jp.co.soramitsu.feature_staking_impl.data.network.blockhain.updaters.AccountNominationsUpdater
@@ -30,6 +30,7 @@ import jp.co.soramitsu.feature_staking_impl.data.network.blockhain.updaters.hist
 import jp.co.soramitsu.feature_staking_impl.data.network.blockhain.updaters.scope.AccountStakingScope
 import jp.co.soramitsu.feature_wallet_api.data.cache.AssetCache
 import jp.co.soramitsu.runtime.multiNetwork.ChainRegistry
+import jp.co.soramitsu.runtime.network.updaters.SingleChainUpdateSystem
 
 @Module
 class StakingUpdatersModule {
@@ -243,7 +244,7 @@ class StakingUpdatersModule {
 
     @Provides
     @FeatureScope
-    fun provideStakingUpdaters(
+    fun provideStakingUpdaterSystem(
         activeEraUpdater: ActiveEraUpdater,
         validatorExposureUpdater: ValidatorExposureUpdater,
         totalIssuanceUpdater: TotalIssuanceUpdater,
@@ -258,8 +259,11 @@ class StakingUpdatersModule {
         minBondUpdater: MinBondUpdater,
         maxNominatorsUpdater: MaxNominatorsUpdater,
         counterForNominatorsUpdater: CounterForNominatorsUpdater,
-    ) = StakingUpdaters(
-        updaters = arrayOf(
+
+        chainRegistry: ChainRegistry,
+        stakingSharedState: StakingSharedState
+    ): UpdateSystem = SingleChainUpdateSystem(
+        updaters = listOf(
             activeEraUpdater,
             validatorExposureUpdater,
             totalIssuanceUpdater,
@@ -274,6 +278,8 @@ class StakingUpdatersModule {
             minBondUpdater,
             maxNominatorsUpdater,
             counterForNominatorsUpdater,
-        )
+        ),
+        chainRegistry = chainRegistry,
+        singleAssetSharedState = stakingSharedState
     )
 }

--- a/feature-staking-impl/src/main/java/jp/co/soramitsu/feature_staking_impl/presentation/staking/main/StakingViewModel.kt
+++ b/feature-staking-impl/src/main/java/jp/co/soramitsu/feature_staking_impl/presentation/staking/main/StakingViewModel.kt
@@ -13,6 +13,7 @@ import jp.co.soramitsu.common.utils.formatAsCurrency
 import jp.co.soramitsu.common.utils.inBackground
 import jp.co.soramitsu.common.utils.withLoading
 import jp.co.soramitsu.common.validation.ValidationExecutor
+import jp.co.soramitsu.core.updater.UpdateSystem
 import jp.co.soramitsu.feature_staking_api.domain.model.StakingState
 import jp.co.soramitsu.feature_staking_api.domain.model.StakingStory
 import jp.co.soramitsu.feature_staking_impl.R
@@ -39,6 +40,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
@@ -59,6 +61,7 @@ class StakingViewModel(
     private val redeemValidationSystem: ManageStakingValidationSystem,
     private val bondMoreValidationSystem: ManageStakingValidationSystem,
     private val validationExecutor: ValidationExecutor,
+    private val stakingUpdateSystem: UpdateSystem
 ) : BaseViewModel(),
     Validatable by validationExecutor {
 
@@ -114,6 +117,11 @@ class StakingViewModel(
         .map { loadingState -> loadingState.map { alerts -> alerts.map(::mapAlertToAlertModel) } }
         .inBackground()
         .asLiveData()
+
+    init {
+        stakingUpdateSystem.start()
+            .launchIn(this)
+    }
 
     private fun mapAlertToAlertModel(alert: Alert): AlertModel {
         return when (alert) {

--- a/feature-staking-impl/src/main/java/jp/co/soramitsu/feature_staking_impl/presentation/staking/main/di/StakingModule.kt
+++ b/feature-staking-impl/src/main/java/jp/co/soramitsu/feature_staking_impl/presentation/staking/main/di/StakingModule.kt
@@ -12,6 +12,7 @@ import jp.co.soramitsu.common.di.viewmodel.ViewModelKey
 import jp.co.soramitsu.common.di.viewmodel.ViewModelModule
 import jp.co.soramitsu.common.resources.ResourceManager
 import jp.co.soramitsu.common.validation.ValidationExecutor
+import jp.co.soramitsu.core.updater.UpdateSystem
 import jp.co.soramitsu.feature_staking_impl.domain.StakingInteractor
 import jp.co.soramitsu.feature_staking_impl.domain.alerts.AlertsInteractor
 import jp.co.soramitsu.feature_staking_impl.domain.rewards.RewardCalculatorFactory
@@ -60,6 +61,7 @@ class StakingModule {
         @Named(SYSTEM_MANAGE_STAKING_REDEEM) redeemValidationSystem: ManageStakingValidationSystem,
         @Named(SYSTEM_MANAGE_STAKING_BOND_MORE) bondMoreValidationSystem: ManageStakingValidationSystem,
         validationExecutor: ValidationExecutor,
+        stakingUpdateSystem: UpdateSystem,
     ): ViewModel {
         return StakingViewModel(
             interactor,
@@ -70,7 +72,8 @@ class StakingModule {
             resourceManager,
             redeemValidationSystem,
             bondMoreValidationSystem,
-            validationExecutor
+            validationExecutor,
+            stakingUpdateSystem
         )
     }
 

--- a/feature-wallet-api/build.gradle
+++ b/feature-wallet-api/build.gradle
@@ -23,6 +23,8 @@ dependencies {
     implementation project(":feature-account-api")
     implementation project(":common")
 
+    implementation daggerDep
+
     implementation fearlessLibDep
 
     implementation androidDep

--- a/feature-wallet-api/src/main/java/jp/co/soramitsu/feature_wallet_api/data/cache/AssetCacheExt.kt
+++ b/feature-wallet-api/src/main/java/jp/co/soramitsu/feature_wallet_api/data/cache/AssetCacheExt.kt
@@ -2,18 +2,28 @@ package jp.co.soramitsu.feature_wallet_api.data.cache
 
 import jp.co.soramitsu.common.data.network.runtime.binding.AccountInfo
 import jp.co.soramitsu.common.data.network.runtime.binding.bindAccountInfo
+import jp.co.soramitsu.core_db.model.AssetLocal
 import jp.co.soramitsu.fearless_utils.runtime.AccountId
 import jp.co.soramitsu.fearless_utils.runtime.RuntimeSnapshot
 import jp.co.soramitsu.runtime.multiNetwork.chain.model.Chain
 
 suspend fun AssetCache.updateAsset(
+    metaId: Long,
     accountId: AccountId,
     chainAsset: Chain.Asset,
     accountInfo: AccountInfo,
-) = updateAsset(accountId, chainAsset) {
+) = updateAsset(metaId, accountId, chainAsset, accountInfoUpdater(accountInfo))
+
+suspend fun AssetCache.updateAsset(
+    accountId: AccountId,
+    chainAsset: Chain.Asset,
+    accountInfo: AccountInfo,
+) = updateAsset(accountId, chainAsset, accountInfoUpdater(accountInfo))
+
+private fun accountInfoUpdater(accountInfo: AccountInfo) = { asset: AssetLocal ->
     val data = accountInfo.data
 
-    it.copy(
+    asset.copy(
         freeInPlanks = data.free,
         reservedInPlanks = data.reserved,
         miscFrozenInPlanks = data.miscFrozen,

--- a/feature-wallet-api/src/main/java/jp/co/soramitsu/feature_wallet_api/data/mappers/Asset.kt
+++ b/feature-wallet-api/src/main/java/jp/co/soramitsu/feature_wallet_api/data/mappers/Asset.kt
@@ -20,6 +20,7 @@ fun mapAssetToAssetModel(
     return with(asset) {
         AssetModel(
             token.configuration.icon,
+            token.configuration.iconUrl,
             token.configuration.symbol,
             resourceManager.getString(patternId, amount)
         )

--- a/feature-wallet-api/src/main/java/jp/co/soramitsu/feature_wallet_api/di/Wallet.kt
+++ b/feature-wallet-api/src/main/java/jp/co/soramitsu/feature_wallet_api/di/Wallet.kt
@@ -1,0 +1,7 @@
+package jp.co.soramitsu.feature_wallet_api.di
+
+import javax.inject.Qualifier
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class Wallet

--- a/feature-wallet-api/src/main/java/jp/co/soramitsu/feature_wallet_api/di/WalletFeatureApi.kt
+++ b/feature-wallet-api/src/main/java/jp/co/soramitsu/feature_wallet_api/di/WalletFeatureApi.kt
@@ -1,5 +1,6 @@
 package jp.co.soramitsu.feature_wallet_api.di
 
+import jp.co.soramitsu.core.updater.UpdateSystem
 import jp.co.soramitsu.feature_wallet_api.data.cache.AssetCache
 import jp.co.soramitsu.feature_wallet_api.domain.interfaces.TokenRepository
 import jp.co.soramitsu.feature_wallet_api.domain.interfaces.WalletConstants
@@ -7,8 +8,6 @@ import jp.co.soramitsu.feature_wallet_api.domain.interfaces.WalletRepository
 import jp.co.soramitsu.feature_wallet_api.domain.model.BuyTokenRegistry
 
 interface WalletFeatureApi {
-
-    fun provideUpdaters(): WalletUpdaters
 
     fun provideWalletRepository(): WalletRepository
 
@@ -19,4 +18,7 @@ interface WalletFeatureApi {
     fun provideAssetCache(): AssetCache
 
     fun provideWallConstants(): WalletConstants
+
+    @Wallet
+    fun provideWalletUpdateSystem(): UpdateSystem
 }

--- a/feature-wallet-api/src/main/java/jp/co/soramitsu/feature_wallet_api/di/WalletUpdaters.kt
+++ b/feature-wallet-api/src/main/java/jp/co/soramitsu/feature_wallet_api/di/WalletUpdaters.kt
@@ -1,5 +1,0 @@
-package jp.co.soramitsu.feature_wallet_api.di
-
-import jp.co.soramitsu.core.updater.Updater
-
-class WalletUpdaters(val updaters: Array<Updater>)

--- a/feature-wallet-api/src/main/java/jp/co/soramitsu/feature_wallet_api/presentation/model/AssetModel.kt
+++ b/feature-wallet-api/src/main/java/jp/co/soramitsu/feature_wallet_api/presentation/model/AssetModel.kt
@@ -2,6 +2,7 @@ package jp.co.soramitsu.feature_wallet_api.presentation.model
 
 data class AssetModel(
     val tokenIconRes: Int,
+    val imageUrl: String,
     val tokenName: String,
     val assetBalance: String
 )

--- a/feature-wallet-impl/src/main/java/jp/co/soramitsu/feature_wallet_impl/data/network/blockchain/updaters/BalancesUpdateSystem.kt
+++ b/feature-wallet-impl/src/main/java/jp/co/soramitsu/feature_wallet_impl/data/network/blockchain/updaters/BalancesUpdateSystem.kt
@@ -9,10 +9,8 @@ import jp.co.soramitsu.runtime.multiNetwork.ChainRegistry
 import jp.co.soramitsu.runtime.multiNetwork.getSocket
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
-import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.flow.onCompletion

--- a/feature-wallet-impl/src/main/java/jp/co/soramitsu/feature_wallet_impl/data/network/blockchain/updaters/BalancesUpdateSystem.kt
+++ b/feature-wallet-impl/src/main/java/jp/co/soramitsu/feature_wallet_impl/data/network/blockchain/updaters/BalancesUpdateSystem.kt
@@ -1,0 +1,42 @@
+package jp.co.soramitsu.feature_wallet_impl.data.network.blockchain.updaters
+
+import jp.co.soramitsu.common.data.network.StorageSubscriptionBuilder
+import jp.co.soramitsu.core.updater.UpdateSystem
+import jp.co.soramitsu.core.updater.Updater
+import jp.co.soramitsu.fearless_utils.wsrpc.request.runtime.storage.subscribeUsing
+import jp.co.soramitsu.runtime.multiNetwork.ChainRegistry
+import jp.co.soramitsu.runtime.multiNetwork.getSocket
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.merge
+import kotlinx.coroutines.flow.onCompletion
+
+class BalancesUpdateSystem(
+    private val chainRegistry: ChainRegistry,
+    private val paymentUpdaterFactory: PaymentUpdaterFactory,
+) : UpdateSystem {
+
+    override fun start(): Flow<Updater.SideEffect> = flow {
+        val chains = chainRegistry.currentChains.first()
+
+        val mergedFlow = chains.map { chain ->
+            val updater = paymentUpdaterFactory.create(chain.id)
+            val socket = chainRegistry.getSocket(chain.id)
+
+            val subscriptionBuilder = StorageSubscriptionBuilder.create(socket)
+
+            val updaterFlow = updater.listenForUpdates(subscriptionBuilder)
+                .flowOn(Dispatchers.Default)
+
+            val cancellable = socket.subscribeUsing(subscriptionBuilder.build())
+
+            updaterFlow.onCompletion { cancellable.cancel() }
+        }.merge()
+
+        emitAll(mergedFlow)
+    }.flowOn(Dispatchers.Default)
+}

--- a/feature-wallet-impl/src/main/java/jp/co/soramitsu/feature_wallet_impl/data/network/blockchain/updaters/BalancesUpdateSystem.kt
+++ b/feature-wallet-impl/src/main/java/jp/co/soramitsu/feature_wallet_impl/data/network/blockchain/updaters/BalancesUpdateSystem.kt
@@ -4,12 +4,14 @@ import jp.co.soramitsu.common.data.network.StorageSubscriptionBuilder
 import jp.co.soramitsu.core.updater.UpdateSystem
 import jp.co.soramitsu.core.updater.Updater
 import jp.co.soramitsu.fearless_utils.wsrpc.request.runtime.storage.subscribeUsing
+import jp.co.soramitsu.feature_account_api.domain.updaters.AccountUpdateScope
 import jp.co.soramitsu.runtime.multiNetwork.ChainRegistry
 import jp.co.soramitsu.runtime.multiNetwork.getSocket
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.merge
@@ -18,25 +20,28 @@ import kotlinx.coroutines.flow.onCompletion
 class BalancesUpdateSystem(
     private val chainRegistry: ChainRegistry,
     private val paymentUpdaterFactory: PaymentUpdaterFactory,
+    private val accountUpdateScope: AccountUpdateScope,
 ) : UpdateSystem {
 
-    override fun start(): Flow<Updater.SideEffect> = flow {
-        val chains = chainRegistry.currentChains.first()
+    override fun start(): Flow<Updater.SideEffect> {
+        return accountUpdateScope.invalidationFlow().flatMapLatest {
+            val chains = chainRegistry.currentChains.first()
 
-        val mergedFlow = chains.map { chain ->
-            val updater = paymentUpdaterFactory.create(chain.id)
-            val socket = chainRegistry.getSocket(chain.id)
+            val mergedFlow = chains.map { chain ->
+                val updater = paymentUpdaterFactory.create(chain.id)
+                val socket = chainRegistry.getSocket(chain.id)
 
-            val subscriptionBuilder = StorageSubscriptionBuilder.create(socket)
+                val subscriptionBuilder = StorageSubscriptionBuilder.create(socket)
 
-            val updaterFlow = updater.listenForUpdates(subscriptionBuilder)
-                .flowOn(Dispatchers.Default)
+                val updaterFlow = updater.listenForUpdates(subscriptionBuilder)
+                    .flowOn(Dispatchers.Default)
 
-            val cancellable = socket.subscribeUsing(subscriptionBuilder.build())
+                val cancellable = socket.subscribeUsing(subscriptionBuilder.build())
 
-            updaterFlow.onCompletion { cancellable.cancel() }
-        }.merge()
+                updaterFlow.onCompletion { cancellable.cancel() }
+            }.merge()
 
-        emitAll(mergedFlow)
-    }.flowOn(Dispatchers.Default)
+            mergedFlow
+        }.flowOn(Dispatchers.Default)
+    }
 }

--- a/feature-wallet-impl/src/main/java/jp/co/soramitsu/feature_wallet_impl/data/network/blockchain/updaters/PaymentUpdater.kt
+++ b/feature-wallet-impl/src/main/java/jp/co/soramitsu/feature_wallet_impl/data/network/blockchain/updaters/PaymentUpdater.kt
@@ -1,6 +1,5 @@
 package jp.co.soramitsu.feature_wallet_impl.data.network.blockchain.updaters
 
-import android.util.Log
 import jp.co.soramitsu.common.data.network.runtime.binding.ExtrinsicStatusEvent
 import jp.co.soramitsu.common.utils.Modules
 import jp.co.soramitsu.common.utils.system

--- a/feature-wallet-impl/src/main/java/jp/co/soramitsu/feature_wallet_impl/data/network/blockchain/updaters/PaymentUpdater.kt
+++ b/feature-wallet-impl/src/main/java/jp/co/soramitsu/feature_wallet_impl/data/network/blockchain/updaters/PaymentUpdater.kt
@@ -66,20 +66,14 @@ class PaymentUpdater(
     override suspend fun listenForUpdates(storageSubscriptionBuilder: SubscriptionBuilder): Flow<Updater.SideEffect> {
         val chain = chainRegistry.getChain(chainId)
 
-        Log.d("RX", "Starting balance updater for $chainId")
-
         val accountId = scope.getAccount().accountIdIn(chain) ?: return emptyFlow()
         val runtime = chainRegistry.getRuntime(chainId)
 
         val key = runtime.metadata.system().storage("Account").storageKey(runtime, accountId)
 
-        Log.d("RX", "Subscribing for balance in $chainId")
-
         return storageSubscriptionBuilder.subscribe(key)
             .onEach { change ->
                 val newAccountInfo = bindAccountInfoOrDefault(change.value, runtime)
-
-                Log.d("RX", "Received new balance info in $chainId")
 
                 assetCache.updateAsset(accountId, chain.utilityAsset, newAccountInfo)
 

--- a/feature-wallet-impl/src/main/java/jp/co/soramitsu/feature_wallet_impl/data/network/blockchain/updaters/PaymentUpdater.kt
+++ b/feature-wallet-impl/src/main/java/jp/co/soramitsu/feature_wallet_impl/data/network/blockchain/updaters/PaymentUpdater.kt
@@ -40,7 +40,7 @@ class PaymentUpdaterFactory(
     private val scope: AccountUpdateScope,
 ) {
 
-    fun create(chainId: ChainId) : PaymentUpdater {
+    fun create(chainId: ChainId): PaymentUpdater {
         return PaymentUpdater(
             substrateSource,
             assetCache,

--- a/feature-wallet-impl/src/main/java/jp/co/soramitsu/feature_wallet_impl/data/network/blockchain/updaters/PaymentUpdater.kt
+++ b/feature-wallet-impl/src/main/java/jp/co/soramitsu/feature_wallet_impl/data/network/blockchain/updaters/PaymentUpdater.kt
@@ -65,6 +65,8 @@ class PaymentUpdater(
     override suspend fun listenForUpdates(storageSubscriptionBuilder: SubscriptionBuilder): Flow<Updater.SideEffect> {
         val chain = chainRegistry.getChain(chainId)
 
+        val metaAccount = scope.getAccount()
+
         val accountId = scope.getAccount().accountIdIn(chain) ?: return emptyFlow()
         val runtime = chainRegistry.getRuntime(chainId)
 
@@ -74,7 +76,7 @@ class PaymentUpdater(
             .onEach { change ->
                 val newAccountInfo = bindAccountInfoOrDefault(change.value, runtime)
 
-                assetCache.updateAsset(accountId, chain.utilityAsset, newAccountInfo)
+                assetCache.updateAsset(metaAccount.id, accountId, chain.utilityAsset, newAccountInfo)
 
                 fetchTransfers(change.block, chain, accountId)
             }

--- a/feature-wallet-impl/src/main/java/jp/co/soramitsu/feature_wallet_impl/di/WalletFeatureDependencies.kt
+++ b/feature-wallet-impl/src/main/java/jp/co/soramitsu/feature_wallet_impl/di/WalletFeatureDependencies.kt
@@ -1,6 +1,7 @@
 package jp.co.soramitsu.feature_wallet_impl.di
 
 import android.content.ContentResolver
+import coil.ImageLoader
 import com.google.gson.Gson
 import jp.co.soramitsu.common.address.AddressIconGenerator
 import jp.co.soramitsu.common.data.network.AppLinksProvider
@@ -90,4 +91,6 @@ interface WalletFeatureDependencies {
     fun localStorageSource(): StorageDataSource
 
     fun extrinsicService(): ExtrinsicService
+
+    fun imageLoader(): ImageLoader
 }

--- a/feature-wallet-impl/src/main/java/jp/co/soramitsu/feature_wallet_impl/di/WalletFeatureModule.kt
+++ b/feature-wallet-impl/src/main/java/jp/co/soramitsu/feature_wallet_impl/di/WalletFeatureModule.kt
@@ -191,9 +191,11 @@ class WalletFeatureModule {
     fun provideFeatureUpdaters(
         chainRegistry: ChainRegistry,
         paymentUpdaterFactory: PaymentUpdaterFactory,
+        accountUpdateScope: AccountUpdateScope,
     ): UpdateSystem = BalancesUpdateSystem(
         chainRegistry,
         paymentUpdaterFactory,
+        accountUpdateScope,
     )
 
     @Provides

--- a/feature-wallet-impl/src/main/java/jp/co/soramitsu/feature_wallet_impl/presentation/balance/list/BalanceListAdapter.kt
+++ b/feature-wallet-impl/src/main/java/jp/co/soramitsu/feature_wallet_impl/presentation/balance/list/BalanceListAdapter.kt
@@ -97,19 +97,17 @@ class AssetViewHolder(override val containerView: View) : RecyclerView.ViewHolde
     }
 
     fun bindRecentChange(asset: AssetModel) = with(containerView) {
-        asset.token.recentRateChange?.let {
-            itemAssetRateChange.setTextColorRes(asset.token.rateChangeColorRes!!)
-            itemAssetRateChange.text = it.formatAsChange()
-        }
+        itemAssetRateChange.setTextColorRes(asset.token.rateChangeColorRes)
+        itemAssetRateChange.text = asset.token.recentRateChange?.formatAsChange()
     }
 
     fun bindDollarInfo(asset: AssetModel) = with(containerView) {
-        asset.token.dollarRate?.let { itemAssetRate.text = it.formatAsCurrency() }
+        itemAssetRate.text = asset.token.dollarRate?.formatAsCurrency()
         bindDollarAmount(asset.dollarAmount)
     }
 
     private fun bindDollarAmount(dollarAmount: BigDecimal?) {
-        dollarAmount?.let { containerView.itemAssetDollarAmount.text = it.formatAsCurrency() }
+        containerView.itemAssetDollarAmount.text = dollarAmount?.formatAsCurrency()
     }
 }
 

--- a/feature-wallet-impl/src/main/java/jp/co/soramitsu/feature_wallet_impl/presentation/balance/list/BalanceListAdapter.kt
+++ b/feature-wallet-impl/src/main/java/jp/co/soramitsu/feature_wallet_impl/presentation/balance/list/BalanceListAdapter.kt
@@ -5,6 +5,8 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
+import coil.ImageLoader
+import coil.load
 import jp.co.soramitsu.common.list.PayloadGenerator
 import jp.co.soramitsu.common.list.resolvePayload
 import jp.co.soramitsu.common.utils.format
@@ -14,7 +16,6 @@ import jp.co.soramitsu.common.utils.inflateChild
 import jp.co.soramitsu.common.utils.setTextColorRes
 import jp.co.soramitsu.common.view.shape.addRipple
 import jp.co.soramitsu.common.view.shape.getCutCornerDrawable
-import jp.co.soramitsu.feature_wallet_api.data.mappers.icon
 import jp.co.soramitsu.feature_wallet_impl.R
 import jp.co.soramitsu.feature_wallet_impl.presentation.model.AssetModel
 import kotlinx.android.extensions.LayoutContainer
@@ -32,7 +33,8 @@ val dollarRateExtractor = { assetModel: AssetModel -> assetModel.token.dollarRat
 val recentChangeExtractor = { assetModel: AssetModel -> assetModel.token.recentRateChange }
 
 class BalanceListAdapter(
-    private val itemHandler: ItemAssetHandler
+    private val imageLoader: ImageLoader,
+    private val itemHandler: ItemAssetHandler,
 ) : ListAdapter<AssetModel, AssetViewHolder>(AssetDiffCallback) {
 
     interface ItemAssetHandler {
@@ -42,7 +44,7 @@ class BalanceListAdapter(
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): AssetViewHolder {
         val view = parent.inflateChild(R.layout.item_asset)
 
-        return AssetViewHolder(view)
+        return AssetViewHolder(view, imageLoader)
     }
 
     override fun onBindViewHolder(holder: AssetViewHolder, position: Int) {
@@ -64,7 +66,10 @@ class BalanceListAdapter(
     }
 }
 
-class AssetViewHolder(override val containerView: View) : RecyclerView.ViewHolder(containerView), LayoutContainer {
+class AssetViewHolder(
+    override val containerView: View,
+    private val imageLoader: ImageLoader,
+) : RecyclerView.ViewHolder(containerView), LayoutContainer {
     init {
         with(containerView) {
             val background = with(context) {
@@ -76,7 +81,7 @@ class AssetViewHolder(override val containerView: View) : RecyclerView.ViewHolde
     }
 
     fun bind(asset: AssetModel, itemHandler: BalanceListAdapter.ItemAssetHandler) = with(containerView) {
-        itemAssetImage.setImageResource(asset.token.configuration.icon)
+        itemAssetImage.load(asset.token.configuration.iconUrl, imageLoader)
         itemAssetNetwork.text = asset.token.configuration.name
 
         bindDollarInfo(asset)

--- a/feature-wallet-impl/src/main/java/jp/co/soramitsu/feature_wallet_impl/presentation/balance/list/BalanceListFragment.kt
+++ b/feature-wallet-impl/src/main/java/jp/co/soramitsu/feature_wallet_impl/presentation/balance/list/BalanceListFragment.kt
@@ -4,7 +4,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import com.google.android.material.bottomsheet.BottomSheetBehavior
+import coil.ImageLoader
 import dev.chrisbanes.insetter.applyInsetter
 import jp.co.soramitsu.common.base.BaseFragment
 import jp.co.soramitsu.common.di.FeatureUtils
@@ -19,8 +19,11 @@ import kotlinx.android.synthetic.main.fragment_balance_list.balanceListAvatar
 import kotlinx.android.synthetic.main.fragment_balance_list.balanceListContent
 import kotlinx.android.synthetic.main.fragment_balance_list.balanceListTotalAmount
 import kotlinx.android.synthetic.main.fragment_balance_list.walletContainer
+import javax.inject.Inject
 
 class BalanceListFragment : BaseFragment<BalanceListViewModel>(), BalanceListAdapter.ItemAssetHandler {
+
+    @Inject protected lateinit var imageLoader: ImageLoader
 
     private lateinit var adapter: BalanceListAdapter
 
@@ -41,7 +44,7 @@ class BalanceListFragment : BaseFragment<BalanceListViewModel>(), BalanceListAda
 
         hideKeyboard()
 
-        adapter = BalanceListAdapter(this)
+        adapter = BalanceListAdapter(imageLoader, this)
         balanceListAssets.adapter = adapter
 
         walletContainer.setOnRefreshListener {
@@ -51,11 +54,6 @@ class BalanceListFragment : BaseFragment<BalanceListViewModel>(), BalanceListAda
         balanceListAvatar.setOnClickListener {
             viewModel.avatarClicked()
         }
-    }
-
-    private fun setRefreshEnabled(bottomSheetState: Int) {
-        val bottomSheetCollapsed = BottomSheetBehavior.STATE_COLLAPSED == bottomSheetState
-        walletContainer.isEnabled = bottomSheetCollapsed
     }
 
     override fun inject() {

--- a/feature-wallet-impl/src/main/java/jp/co/soramitsu/feature_wallet_impl/presentation/balance/list/BalanceListFragment.kt
+++ b/feature-wallet-impl/src/main/java/jp/co/soramitsu/feature_wallet_impl/presentation/balance/list/BalanceListFragment.kt
@@ -13,16 +13,11 @@ import jp.co.soramitsu.common.utils.hideKeyboard
 import jp.co.soramitsu.feature_wallet_api.di.WalletFeatureApi
 import jp.co.soramitsu.feature_wallet_impl.R
 import jp.co.soramitsu.feature_wallet_impl.di.WalletFeatureComponent
-import jp.co.soramitsu.feature_wallet_impl.presentation.balance.assetActions.buy.setupBuyIntegration
 import jp.co.soramitsu.feature_wallet_impl.presentation.model.AssetModel
-import jp.co.soramitsu.feature_wallet_impl.presentation.transaction.history.showState
-import kotlinx.android.synthetic.main.fragment_balance_list.balanceListActions
 import kotlinx.android.synthetic.main.fragment_balance_list.balanceListAssets
 import kotlinx.android.synthetic.main.fragment_balance_list.balanceListAvatar
 import kotlinx.android.synthetic.main.fragment_balance_list.balanceListContent
 import kotlinx.android.synthetic.main.fragment_balance_list.balanceListTotalAmount
-import kotlinx.android.synthetic.main.fragment_balance_list.container
-import kotlinx.android.synthetic.main.fragment_balance_list.transfersContainer
 import kotlinx.android.synthetic.main.fragment_balance_list.walletContainer
 
 class BalanceListFragment : BaseFragment<BalanceListViewModel>(), BalanceListAdapter.ItemAssetHandler {
@@ -38,9 +33,9 @@ class BalanceListFragment : BaseFragment<BalanceListViewModel>(), BalanceListAda
     }
 
     override fun initViews() {
-        container.applyInsetter {
+        balanceListContent.applyInsetter {
             type(statusBars = true) {
-                margin()
+                padding()
             }
         }
 
@@ -49,29 +44,8 @@ class BalanceListFragment : BaseFragment<BalanceListViewModel>(), BalanceListAda
         adapter = BalanceListAdapter(this)
         balanceListAssets.adapter = adapter
 
-        transfersContainer.initializeBehavior(anchorView = balanceListContent)
-
-        transfersContainer.setScrollingListener(viewModel::transactionsScrolled)
-
-        transfersContainer.setSlidingStateListener(this::setRefreshEnabled)
-        transfersContainer.setFilterClickListener { viewModel.filterClicked() }
-
-        transfersContainer.setTransactionClickListener(viewModel::transactionClicked)
-
         walletContainer.setOnRefreshListener {
             viewModel.sync()
-        }
-
-        balanceListActions.send.setOnClickListener {
-            viewModel.sendClicked()
-        }
-
-        balanceListActions.receive.setOnClickListener {
-            viewModel.receiveClicked()
-        }
-
-        balanceListActions.buy.setOnClickListener {
-            viewModel.buyClicked()
         }
 
         balanceListAvatar.setOnClickListener {
@@ -96,12 +70,6 @@ class BalanceListFragment : BaseFragment<BalanceListViewModel>(), BalanceListAda
 
     override fun subscribe(viewModel: BalanceListViewModel) {
         viewModel.sync()
-
-        setupBuyIntegration(viewModel)
-
-        viewModel.state.observe(transfersContainer::showState)
-
-        viewModel.buyEnabledLiveData.observe(balanceListActions.buy::setEnabled)
 
         viewModel.balanceLiveData.observe {
             adapter.submitList(it.assetModels)

--- a/feature-wallet-impl/src/main/java/jp/co/soramitsu/feature_wallet_impl/presentation/balance/list/BalanceListViewModel.kt
+++ b/feature-wallet-impl/src/main/java/jp/co/soramitsu/feature_wallet_impl/presentation/balance/list/BalanceListViewModel.kt
@@ -7,7 +7,6 @@ import jp.co.soramitsu.common.address.AddressIconGenerator
 import jp.co.soramitsu.common.address.AddressModel
 import jp.co.soramitsu.common.base.BaseViewModel
 import jp.co.soramitsu.common.utils.Event
-import jp.co.soramitsu.common.utils.map
 import jp.co.soramitsu.core.model.Node
 import jp.co.soramitsu.core.model.chainId
 import jp.co.soramitsu.feature_wallet_api.domain.interfaces.WalletInteractor
@@ -15,15 +14,8 @@ import jp.co.soramitsu.feature_wallet_api.domain.model.WalletAccount
 import jp.co.soramitsu.feature_wallet_impl.data.mappers.mapAssetToAssetModel
 import jp.co.soramitsu.feature_wallet_impl.presentation.AssetPayload
 import jp.co.soramitsu.feature_wallet_impl.presentation.WalletRouter
-import jp.co.soramitsu.feature_wallet_impl.presentation.balance.assetActions.buy.BuyMixin
 import jp.co.soramitsu.feature_wallet_impl.presentation.balance.list.model.BalanceModel
 import jp.co.soramitsu.feature_wallet_impl.presentation.model.AssetModel
-import jp.co.soramitsu.feature_wallet_impl.presentation.transaction.history.mixin.TransactionHistoryMixin
-import jp.co.soramitsu.feature_wallet_impl.presentation.transaction.history.mixin.TransactionHistoryUi
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.async
-import kotlinx.coroutines.awaitAll
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
@@ -34,11 +26,7 @@ class BalanceListViewModel(
     private val interactor: WalletInteractor,
     private val addressIconGenerator: AddressIconGenerator,
     private val router: WalletRouter,
-    private val buyMixin: BuyMixin.Presentation,
-    private val transactionHistoryMixin: TransactionHistoryMixin,
-) : BaseViewModel(),
-    TransactionHistoryUi by transactionHistoryMixin,
-    BuyMixin by buyMixin {
+) : BaseViewModel() {
 
     private val _hideRefreshEvent = MutableLiveData<Event<Unit>>()
     val hideRefreshEvent: LiveData<Event<Unit>> = _hideRefreshEvent
@@ -47,40 +35,15 @@ class BalanceListViewModel(
 
     val balanceLiveData = balanceFlow().asLiveData()
 
-    private val primaryTokenLiveData = balanceLiveData.map { it.assetModels.first().token.configuration }
-
-    val buyEnabledLiveData = primaryTokenLiveData.map(initial = false) {
-        buyMixin.isBuyEnabled(it.chainId, it.id)
-    }
 
     fun sync() {
         viewModelScope.launch {
-            val deferredAssetSync = async(Dispatchers.Default) { interactor.syncAssetsRates() }
-            val deferredTransactionsSync = async(Dispatchers.Default) { transactionHistoryMixin.syncFirstOperationsPage() }
+            val result = interactor.syncAssetsRates()
 
-            val results = awaitAll(deferredAssetSync, deferredTransactionsSync)
-
-            val firstError = results.mapNotNull { it.exceptionOrNull() }
-                .firstOrNull()
-
-            firstError?.let(::showError)
+            result.exceptionOrNull()?.let(::showError)
 
             _hideRefreshEvent.value = Event(Unit)
         }
-    }
-
-    override fun onCleared() {
-        super.onCleared()
-
-        transactionHistoryMixin.cancel()
-    }
-
-    fun transactionsScrolled(index: Int) {
-        transactionHistoryMixin.scrolled(index)
-    }
-
-    fun filterClicked() {
-        router.openFilter()
     }
 
     fun assetClicked(asset: AssetModel) {
@@ -90,21 +53,6 @@ class BalanceListViewModel(
         )
 
         router.openAssetDetails(payload)
-    }
-
-    fun sendClicked() {
-        router.openChooseRecipient()
-    }
-
-    fun receiveClicked() {
-        router.openReceive()
-    }
-
-    fun buyClicked() {
-//        val address = currentAddressModelLiveData.value?.address ?: return
-//        val token = primaryTokenLiveData.value ?: return
-//
-//        buyMixin.buyClicked(token, address)
     }
 
     fun avatarClicked() {

--- a/feature-wallet-impl/src/main/java/jp/co/soramitsu/feature_wallet_impl/presentation/balance/list/BalanceListViewModel.kt
+++ b/feature-wallet-impl/src/main/java/jp/co/soramitsu/feature_wallet_impl/presentation/balance/list/BalanceListViewModel.kt
@@ -35,7 +35,6 @@ class BalanceListViewModel(
 
     val balanceLiveData = balanceFlow().asLiveData()
 
-
     fun sync() {
         viewModelScope.launch {
             val result = interactor.syncAssetsRates()

--- a/feature-wallet-impl/src/main/java/jp/co/soramitsu/feature_wallet_impl/presentation/balance/list/di/BalanceListModule.kt
+++ b/feature-wallet-impl/src/main/java/jp/co/soramitsu/feature_wallet_impl/presentation/balance/list/di/BalanceListModule.kt
@@ -16,7 +16,6 @@ import jp.co.soramitsu.core.model.chainId
 import jp.co.soramitsu.feature_account_api.presenatation.account.AddressDisplayUseCase
 import jp.co.soramitsu.feature_wallet_api.domain.interfaces.WalletInteractor
 import jp.co.soramitsu.feature_wallet_impl.presentation.WalletRouter
-import jp.co.soramitsu.feature_wallet_impl.presentation.balance.assetActions.buy.BuyMixin
 import jp.co.soramitsu.feature_wallet_impl.presentation.balance.list.BalanceListViewModel
 import jp.co.soramitsu.feature_wallet_impl.presentation.transaction.filter.HistoryFiltersProvider
 import jp.co.soramitsu.feature_wallet_impl.presentation.transaction.history.mixin.TransactionHistoryMixin
@@ -54,16 +53,12 @@ class BalanceListModule {
         interactor: WalletInteractor,
         router: WalletRouter,
         addressIconGenerator: AddressIconGenerator,
-        buyMixin: BuyMixin.Presentation,
-        transactionHistoryMixin: TransactionHistoryMixin,
     ): ViewModel {
 
         return BalanceListViewModel(
             interactor,
             addressIconGenerator,
-            router,
-            buyMixin,
-            transactionHistoryMixin,
+            router
         )
     }
 

--- a/feature-wallet-impl/src/main/java/jp/co/soramitsu/feature_wallet_impl/presentation/model/TokenModel.kt
+++ b/feature-wallet-impl/src/main/java/jp/co/soramitsu/feature_wallet_impl/presentation/model/TokenModel.kt
@@ -13,8 +13,8 @@ class TokenModel(
 ) {
     val rateChangeColorRes = determineChangeColor()
 
-    private fun determineChangeColor(): Int? {
-        if (recentRateChange == null) return null
+    private fun determineChangeColor(): Int {
+        if (recentRateChange == null) return R.color.gray2
 
         return if (recentRateChange.isNonNegative) R.color.green else R.color.red
     }

--- a/feature-wallet-impl/src/main/res/layout/fragment_balance_list.xml
+++ b/feature-wallet-impl/src/main/res/layout/fragment_balance_list.xml
@@ -6,99 +6,69 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <FrameLayout
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/balanceListContent"
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="match_parent"
+        tools:context=".presentation.balance.list.BalanceListFragment">
 
-        <androidx.coordinatorlayout.widget.CoordinatorLayout
-            android:id="@+id/container"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent">
+        <TextView
+            android:id="@+id/balanceListTotalTitle"
+            style="@style/TextAppearance.Soramitsu.Body1"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="16dp"
+            android:text="@string/wallet_assets_total_title"
+            android:textColor="@color/colorAccent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
 
-            <androidx.constraintlayout.widget.ConstraintLayout
-                android:id="@+id/balanceListContent"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                tools:context=".presentation.balance.list.BalanceListFragment">
+        <TextView
+            android:id="@+id/balanceListTotalAmount"
+            style="@style/TextAppearance.Soramitsu.Header1"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="16dp"
+            android:ellipsize="end"
+            android:singleLine="true"
+            app:layout_constraintEnd_toStartOf="@+id/balanceListAvatar"
+            app:layout_constraintHorizontal_bias="0.0"
+            app:layout_constraintStart_toStartOf="@+id/balanceListTotalTitle"
+            app:layout_constraintTop_toBottomOf="@+id/balanceListTotalTitle"
+            tools:text="$21,000.43" />
 
-                <TextView
-                    android:id="@+id/balanceListTotalTitle"
-                    style="@style/TextAppearance.Soramitsu.Body1"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginStart="16dp"
-                    android:layout_marginTop="16dp"
-                    android:text="@string/wallet_assets_total_title"
-                    android:textColor="@color/colorAccent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toTopOf="parent" />
+        <ImageView
+            android:id="@+id/balanceListAvatar"
+            android:layout_width="@dimen/avatar_size"
+            android:layout_height="@dimen/avatar_size"
+            android:layout_marginTop="28dp"
+            android:layout_marginEnd="16dp"
+            android:src="@color/white"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
 
-                <TextView
-                    android:id="@+id/balanceListTotalAmount"
-                    style="@style/TextAppearance.Soramitsu.Header1"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_marginEnd="16dp"
-                    android:ellipsize="end"
-                    android:singleLine="true"
-                    app:layout_constraintEnd_toStartOf="@+id/balanceListAvatar"
-                    app:layout_constraintHorizontal_bias="0.0"
-                    app:layout_constraintStart_toStartOf="@+id/balanceListTotalTitle"
-                    app:layout_constraintTop_toBottomOf="@+id/balanceListTotalTitle"
-                    tools:text="$21,000.43" />
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/balanceListAssets"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:layout_marginStart="16dp"
+            android:layout_marginEnd="16dp"
+            android:overScrollMode="never"
+            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/balanceListTotalAmount"
+            tools:itemCount="2"
+            tools:listitem="@layout/item_asset" />
 
-                <ImageView
-                    android:id="@+id/balanceListAvatar"
-                    android:layout_width="@dimen/avatar_size"
-                    android:layout_height="@dimen/avatar_size"
-                    android:layout_marginTop="28dp"
-                    android:layout_marginEnd="16dp"
-                    android:src="@color/white"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintTop_toTopOf="parent" />
+        <androidx.constraintlayout.widget.Guideline
+            android:id="@+id/guideline"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            app:layout_constraintGuide_percent="0.5" />
 
-                <androidx.recyclerview.widget.RecyclerView
-                    android:id="@+id/balanceListAssets"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_marginStart="16dp"
-                    android:layout_marginEnd="16dp"
-                    android:overScrollMode="never"
-                    app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@+id/balanceListTotalAmount"
-                    tools:itemCount="2"
-                    tools:listitem="@layout/item_asset" />
-
-                <jp.co.soramitsu.feature_wallet_impl.presentation.balance.assetActions.AssetActionsView
-                    android:id="@+id/balanceListActions"
-                    android:layout_width="0dp"
-                    android:layout_height="@dimen/asset_height"
-                    android:layout_marginTop="8dp"
-                    android:layout_marginBottom="16dp"
-                    app:layout_constraintBottom_toBottomOf="parent"
-                    app:layout_constraintEnd_toEndOf="@id/balanceListAssets"
-                    app:layout_constraintStart_toStartOf="@+id/balanceListAssets"
-                    app:layout_constraintTop_toBottomOf="@+id/balanceListAssets" />
-
-                <androidx.constraintlayout.widget.Guideline
-                    android:id="@+id/guideline"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:orientation="vertical"
-                    app:layout_constraintGuide_percent="0.5" />
-
-            </androidx.constraintlayout.widget.ConstraintLayout>
-
-            <jp.co.soramitsu.feature_wallet_impl.presentation.transaction.history.TransferHistorySheet
-                android:id="@+id/transfersContainer"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                app:layout_behavior="jp.co.soramitsu.common.view.bottomSheet.LockBottomSheetBehavior"
-                tools:layout_height="350dp" />
-
-        </androidx.coordinatorlayout.widget.CoordinatorLayout>
-
-    </FrameLayout>
+    </androidx.constraintlayout.widget.ConstraintLayout>
 </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>

--- a/runtime/src/main/java/jp/co/soramitsu/runtime/multiNetwork/chain/Mappers.kt
+++ b/runtime/src/main/java/jp/co/soramitsu/runtime/multiNetwork/chain/Mappers.kt
@@ -30,6 +30,7 @@ fun mapChainRemoteToChain(
 
     val assets = chainRemote.assets.map {
         Chain.Asset(
+            iconUrl = chainRemote.icon,
             chainId = chainRemote.chainId,
             id = it.assetId,
             symbol = it.symbol,
@@ -92,6 +93,7 @@ fun mapChainLocalToChain(chainLocal: JoinedChainInfo): Chain {
 
     val assets = chainLocal.assets.map {
         Chain.Asset(
+            iconUrl = chainLocal.chain.icon,
             id = it.id,
             symbol = it.symbol,
             precision = it.precision,

--- a/runtime/src/main/java/jp/co/soramitsu/runtime/multiNetwork/chain/model/Chain.kt
+++ b/runtime/src/main/java/jp/co/soramitsu/runtime/multiNetwork/chain/model/Chain.kt
@@ -25,6 +25,7 @@ data class Chain(
     )
 
     data class Asset(
+        val iconUrl: String,
         val id: Int,
         val priceId: String?,
         val chainId: ChainId,

--- a/runtime/src/main/java/jp/co/soramitsu/runtime/network/updaters/SingleChainUpdateSystem.kt
+++ b/runtime/src/main/java/jp/co/soramitsu/runtime/network/updaters/SingleChainUpdateSystem.kt
@@ -1,47 +1,43 @@
-package jp.co.soramitsu.app.root.domain
+package jp.co.soramitsu.runtime.network.updaters
 
 import jp.co.soramitsu.common.data.network.StorageSubscriptionBuilder
 import jp.co.soramitsu.common.utils.hasModule
-import jp.co.soramitsu.core.model.Node
-import jp.co.soramitsu.core.model.chainId
+import jp.co.soramitsu.core.updater.UpdateSystem
 import jp.co.soramitsu.core.updater.Updater
 import jp.co.soramitsu.fearless_utils.wsrpc.request.runtime.storage.subscribeUsing
 import jp.co.soramitsu.runtime.multiNetwork.ChainRegistry
 import jp.co.soramitsu.runtime.multiNetwork.getRuntime
 import jp.co.soramitsu.runtime.multiNetwork.getSocket
+import jp.co.soramitsu.runtime.state.SingleAssetSharedState
+import jp.co.soramitsu.runtime.state.selectedChainFlow
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flatMapLatest
-import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.flow.onCompletion
 
-// TODO update system - split
-class UpdateSystem(
+class SingleChainUpdateSystem(
     private val updaters: List<Updater>,
     private val chainRegistry: ChainRegistry,
-) {
+    private val singleAssetSharedState: SingleAssetSharedState,
+) : UpdateSystem {
 
-    fun start(): Flow<Updater.SideEffect> = flow {
-        val firstChain = chainRegistry.getChain(Node.NetworkType.POLKADOT.chainId)
-        val socket = chainRegistry.getSocket(firstChain.id)
-        val runtime = chainRegistry.getRuntime(firstChain.id)
+    override fun start(): Flow<Updater.SideEffect> = singleAssetSharedState.selectedChainFlow().flatMapLatest { chain ->
+        val socket = chainRegistry.getSocket(chain.id)
+        val runtimeMetadata = chainRegistry.getRuntime(chain.id).metadata
 
         val scopeFlows = updaters.groupBy(Updater::scope).map { (scope, scopeUpdaters) ->
             scope.invalidationFlow().flatMapLatest {
-                val runtimeMetadata = runtime.metadata
-
                 val subscriptionBuilder = StorageSubscriptionBuilder.create(socket)
 
                 val updatersFlow = scopeUpdaters
                     .filter { it.requiredModules.all(runtimeMetadata::hasModule) }
-                    .map { it.listenForUpdates(subscriptionBuilder).flowOn(Dispatchers.IO) }
+                    .map { it.listenForUpdates(subscriptionBuilder).flowOn(Dispatchers.Default) }
 
                 if (updatersFlow.isNotEmpty()) {
-                    val cancellable = socket.subscribeUsing(subscriptionBuilder.proxy.build())
+                    val cancellable = socket.subscribeUsing(subscriptionBuilder.build())
 
                     updatersFlow.merge().onCompletion {
                         cancellable.cancel()
@@ -52,6 +48,6 @@ class UpdateSystem(
             }
         }
 
-        emitAll(scopeFlows.merge())
+        scopeFlows.merge()
     }.flowOn(Dispatchers.Default)
 }

--- a/runtime/src/main/java/jp/co/soramitsu/runtime/state/SingleAssetSharedState.kt
+++ b/runtime/src/main/java/jp/co/soramitsu/runtime/state/SingleAssetSharedState.kt
@@ -3,7 +3,9 @@ package jp.co.soramitsu.runtime.state
 import jp.co.soramitsu.common.data.holders.ChainIdHolder
 import jp.co.soramitsu.runtime.multiNetwork.chain.model.Chain
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
 
 interface SingleAssetSharedState : ChainIdHolder {
 
@@ -18,6 +20,10 @@ interface SingleAssetSharedState : ChainIdHolder {
         return selectedAsset.first().chain.id
     }
 }
+
+fun SingleAssetSharedState.selectedChainFlow() = selectedAsset
+    .map { it.chain }
+    .distinctUntilChanged()
 
 suspend fun SingleAssetSharedState.chain() = selectedAsset.first().chain
 


### PR DESCRIPTION
Splits update system into 3 separate ones:
* BalanceUpdateSystem - update balances across all chains, runs in the global scope (but resubscribes in case of meta account switch)
* StakingSystem - runs in the scope of staking tab
* CrowfloanSystem - runs in the scope of crowdloan tab

Also introduces some minor UI and logic changes to display synced balances:
* Ensure token is present in database before inserting updated balance to correctly perform inner join during observeAssets()
* Remoted transaction history and buy/send/receive panel from main wallet screen
* Minor ui fixes in asset list