### PR TITLE
[DOPS-1626] Set up Google play publishing

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,11 @@
-@Library('jenkins-library' ) _
+@Library('jenkins-library')
 
-def pipeline = new org.android.AppPipeline(steps: this, sonar: false, testCmd: 'runTest', dockerImage: 'build-tools/android-build-box-jdk11')
+def pipeline = new org.android.AppPipeline(
+    steps:            this,
+    sonar:            false,
+    pushReleaseNotes: false,
+    testCmd:          'runTest',
+    dockerImage:      'build-tools/android-build-box-jdk11',
+    publishCmd:       'publishReleaseApk'
+)
 pipeline.runPipeline('fearless')


### PR DESCRIPTION
# Task

[DOPS-1626] Set up Google play publishing.

## Changes

1. Update Jenkins library.
2. Configure Jenkinsfile to be able to push an app directly to Google Play.

## Tests

[2.0.3](https://jenkins.soramitsu.co.jp/job/fearless/job/fearless-Android/view/tags/job/2.0.3/)
[2.0.2](https://jenkins.soramitsu.co.jp/job/fearless/job/fearless-Android/view/tags/job/2.0.2/)




Signed-off-by: Dmitriy Creed <creed@soramitsu.co.jp>

[DOPS-1626]: https://soramitsu.atlassian.net/browse/DOPS-1626?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ