### PR TITLE
use latest tag for android build box

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ def pipeline = new org.android.AppPipeline(
     sonar:            false,
     pushReleaseNotes: false,
     testCmd:          'runTest',
-    dockerImage:      'build-tools/android-build-box-jdk11',
+    dockerImage:      'build-tools/android-build-box-jdk11:latest',
     publishCmd:       'publishReleaseApk'
 )
 pipeline.runPipeline('fearless')


### PR DESCRIPTION
# Task
1. Use ':latest' tag for android build box Docker Image.

Signed-off-by: Ahmed Elkashef <elkashef@soramitsu.co.jp>