### PR TITLE
Fix GitHub spelling

### DIFF
--- a/common/src/main/res/values-ru/strings.xml
+++ b/common/src/main/res/values-ru/strings.xml
@@ -84,7 +84,7 @@
     <string name="social_media">Social Media</string>
     <string name="support_and_feedback">Поддержка и Обратная связь</string>
     <string name="about_website">Официальный сайт</string>
-    <string name="about_github">Исходный код на Github</string>
+    <string name="about_github">Исходный код на GitHub</string>
     <string name="about_telegram">Присоединяйтесь к группе Telegram</string>
     <string name="common_email_chooser_title">Выберите приложение для работы с почтой</string>
     <string name="common_skip_process">Пропустить</string>

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -88,7 +88,7 @@ operations\nwill appear here</string>
     <string name="social_media">Social Media</string>
     <string name="support_and_feedback">Support &amp; Feedback</string>
     <string name="about_website">Official Website</string>
-    <string name="about_github">Github Source Code</string>
+    <string name="about_github">GitHub Source Code</string>
     <string name="about_telegram">Join on Telegram</string>
     <string name="common_email_chooser_title">Select email app</string>
     <string name="common_skip_process">Skip process</string>


### PR DESCRIPTION
Just a minor typo fix: `Github` -> `GitHub`.