### PR TITLE
fixes/FLW-2944-2826-2888

### DIFF
--- a/common/src/main/java/jp/co/soramitsu/common/compose/component/FullScreenLoading.kt
+++ b/common/src/main/java/jp/co/soramitsu/common/compose/component/FullScreenLoading.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
@@ -26,15 +27,19 @@ import jp.co.soramitsu.common.compose.theme.transparent
 import jp.co.soramitsu.common.compose.theme.white08
 
 @Composable
-fun FullScreenLoading(isLoading: Boolean, BlurredContent: @Composable () -> Unit) {
+fun FullScreenLoading(
+    isLoading: Boolean,
+    contentAlignment: Alignment = Alignment.TopStart,
+    BlurredContent: @Composable () -> Unit
+) {
     val blurModifier = if (isLoading) Modifier.blur(10.dp) else Modifier
     Box(
-        modifier = Modifier
-            .fillMaxSize()
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = contentAlignment
     ) {
         Box(
             modifier = Modifier
-                .fillMaxSize()
+                .fillMaxWidth()
                 .then(blurModifier)
         ) {
             BlurredContent()

--- a/common/src/main/res/values-ru/strings.xml
+++ b/common/src/main/res/values-ru/strings.xml
@@ -936,6 +936,9 @@
     <string name="polkaswap_liqudity_fee_title">Комиссия провайдера ликвидности</string>
     <string name="polkaswap_liqudity_fee_info">Часть каждой сделки (0,3%) является награждением для поставщиков ликвидности.</string>
     <string name="polkaswap_network_fee_info">Плата за сеть используется для обеспечения роста и стабильной работы системы SORA.</string>
+    <string name="all_done_alert_result_stub">Результат</string>
+    <string name="all_done_alert_success_stub">Успешно</string>
+
 
     <string name="polkaswap_confirmation_swapped_stub">Swapped</string>
 </resources>

--- a/common/src/main/res/values-ru/strings.xml
+++ b/common/src/main/res/values-ru/strings.xml
@@ -938,7 +938,5 @@
     <string name="polkaswap_network_fee_info">Плата за сеть используется для обеспечения роста и стабильной работы системы SORA.</string>
     <string name="all_done_alert_result_stub">Результат</string>
     <string name="all_done_alert_success_stub">Успешно</string>
-
-
     <string name="polkaswap_confirmation_swapped_stub">Swapped</string>
 </resources>

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -1036,5 +1036,4 @@ Remember to make a backup of your key and keep it in a safe and private place (e
     <string name="all_done_alert_success_stub">Success</string>
     <string name="polkaswap_confirmation_swap_stub">Swap</string>
     <string name="polkaswap_confirmation_swapped_stub">Swapped</string>
-
 </resources>

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -1032,6 +1032,8 @@ Remember to make a backup of your key and keep it in a safe and private place (e
     <string name="polkaswap_liqudity_fee_title">Liquidity provider fee</string>
     <string name="polkaswap_liqudity_fee_info">A portion of each trade (0.3%) goes to liquidity providers as a protocol incentive.</string>
     <string name="polkaswap_network_fee_info">Network fee is used to ensure SORA system\'s growth and stable performance.</string>
+    <string name="all_done_alert_result_stub">Result</string>
+    <string name="all_done_alert_success_stub">Success</string>
     <string name="polkaswap_confirmation_swap_stub">Swap</string>
     <string name="polkaswap_confirmation_swapped_stub">Swapped</string>
 

--- a/feature-success-impl/src/main/kotlin/jp/co/soramitsu/success/presentation/SuccessViewModel.kt
+++ b/feature-success-impl/src/main/kotlin/jp/co/soramitsu/success/presentation/SuccessViewModel.kt
@@ -8,6 +8,7 @@ import jp.co.soramitsu.account.api.presentation.actions.ExternalAccountActions
 import jp.co.soramitsu.common.R
 import jp.co.soramitsu.common.base.BaseViewModel
 import jp.co.soramitsu.common.compose.component.TitleValueViewState
+import jp.co.soramitsu.common.compose.theme.greenText
 import jp.co.soramitsu.common.data.network.BlockExplorerUrlBuilder
 import jp.co.soramitsu.common.mixin.api.Browserable
 import jp.co.soramitsu.common.resources.ClipboardManager
@@ -75,6 +76,11 @@ class SuccessViewModel @Inject constructor(
             title = resourceManager.getString(R.string.hash),
             value = operationHash?.shorten(),
             clickState = TitleValueViewState.ClickState(R.drawable.ic_copy_filled_24, SuccessViewState.CODE_HASH_CLICK)
+        ),
+        TitleValueViewState(
+            title = resourceManager.getString(R.string.all_done_alert_result_stub),
+            value = resourceManager.getString(R.string.all_done_alert_success_stub),
+            valueColor = greenText
         )
     )
 

--- a/feature-wallet-api/src/main/java/jp/co/soramitsu/wallet/api/domain/ValidateTransferUseCase.kt
+++ b/feature-wallet-api/src/main/java/jp/co/soramitsu/wallet/api/domain/ValidateTransferUseCase.kt
@@ -1,6 +1,5 @@
 package jp.co.soramitsu.wallet.api.domain
 
-import java.math.BigInteger
 import jp.co.soramitsu.common.base.errors.ValidationException
 import jp.co.soramitsu.common.resources.ResourceManager
 import jp.co.soramitsu.common.validation.DeadRecipientException
@@ -10,6 +9,7 @@ import jp.co.soramitsu.common.validation.TransferAddressNotValidException
 import jp.co.soramitsu.common.validation.TransferToTheSameAddressException
 import jp.co.soramitsu.common.validation.WaitForFeeCalculationException
 import jp.co.soramitsu.wallet.impl.domain.model.Asset
+import java.math.BigInteger
 
 interface ValidateTransferUseCase {
     suspend operator fun invoke(
@@ -17,7 +17,8 @@ interface ValidateTransferUseCase {
         asset: Asset,
         recipientAddress: String,
         ownAddress: String,
-        fee: BigInteger?
+        fee: BigInteger?,
+        confirmedValidations: List<TransferValidationResult> = emptyList()
     ): Result<TransferValidationResult>
 }
 

--- a/feature-wallet-impl/src/main/java/jp/co/soramitsu/wallet/impl/presentation/send/confirm/ConfirmSendContent.kt
+++ b/feature-wallet-impl/src/main/java/jp/co/soramitsu/wallet/impl/presentation/send/confirm/ConfirmSendContent.kt
@@ -2,8 +2,6 @@ package jp.co.soramitsu.wallet.impl.presentation.send.confirm
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -76,9 +74,12 @@ fun ConfirmSendContent(
     callback: ConfirmSendScreenInterface
 ) {
     val keyboardController = LocalSoftwareKeyboardController.current
-    FullScreenLoading(isLoading = state.isLoading) {
+    FullScreenLoading(
+        isLoading = state.isLoading,
+        contentAlignment = Alignment.BottomStart
+    ) {
         BottomSheetScreen {
-            Box(Modifier.fillMaxSize()) {
+            Box(Modifier.fillMaxWidth()) {
                 Column(
                     modifier = Modifier
                         .padding(horizontal = 16.dp)
@@ -120,7 +121,6 @@ fun ConfirmSendContent(
                     )
                     MarginVertical(margin = 24.dp)
                     InfoTable(items = state.tableItems, onItemClick = callback::onItemClick)
-                    Spacer(modifier = Modifier.weight(1f))
                     MarginVertical(margin = 12.dp)
 
                     AccentButton(

--- a/feature-wallet-impl/src/main/java/jp/co/soramitsu/wallet/impl/presentation/send/setup/SendSetupFragment.kt
+++ b/feature-wallet-impl/src/main/java/jp/co/soramitsu/wallet/impl/presentation/send/setup/SendSetupFragment.kt
@@ -59,13 +59,13 @@ class SendSetupFragment : BaseComposeBottomSheetDialogFragment<SendSetupViewMode
         viewModel.openScannerEvent.observeEvent {
             requestCameraPermission()
         }
-        viewModel.openValidationWarningEvent.observeEvent {
+        viewModel.openValidationWarningEvent.observeEvent { (result, warning) ->
             ErrorDialog(
-                title = it.message,
-                message = it.explanation,
-                positiveButtonText = it.positiveButtonText,
-                negativeButtonText = it.negativeButtonText,
-                positiveClick = viewModel::existentialDepositWarningConfirmed,
+                title = warning.message,
+                message = warning.explanation,
+                positiveButtonText = warning.positiveButtonText,
+                negativeButtonText = warning.negativeButtonText,
+                positiveClick = { viewModel.warningConfirmed(result) },
                 isHideable = false
             ).show(childFragmentManager)
         }


### PR DESCRIPTION
FLW-2888 Confirm menu centered on Preview screen during send on KSM
FLW-2826 Add the operation's success or failed status as a result in the notification after the Send transaction is executed
FLW-2944 The "Insufficient balance" alert isn't immediately shown if we send tokens to our own wallet with a zero balance