### PR TITLE
Migrate from deprecated WalletConnect to Reown SDK

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -233,7 +233,9 @@ dependencies {
 
     implementation libs.insetter.widgets
 
+    // JNA is added as direct dependency to prevent class duplication from 3rd party libraries
     implementation libs.jna
+    // Exclude JNA from beacon SDK to prevent class duplication - using direct JNA dependency above
     implementation libs.beacon.android.sdk, withoutJna
 
     kspAndroidTest libs.hilt.compiler
@@ -245,9 +247,10 @@ dependencies {
     implementation libs.sora.ui
     implementation(libs.soramitsu.android.foundation)
 
-    implementation platform(libs.walletconnectBomDep)
-    implementation libs.walletconnectCoreDep
-    implementation libs.walletconnectWeb3WalletDep
+    implementation platform(libs.reownBomDep)
+    // Exclude JNA from Reown libraries to prevent class duplication - using direct JNA dependency above
+    implementation libs.reownCoreDep, withoutJna
+    implementation libs.reownWalletKitDep, withoutJna
 
     androidTestImplementation libs.runner
     androidTestImplementation libs.rules

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -254,3 +254,9 @@
 # Retain generic signatures of TypeToken and its subclasses with R8 version 3.0 and higher.
 -keep,allowobfuscation,allowshrinking class com.google.gson.reflect.TypeToken
 -keep,allowobfuscation,allowshrinking class * extends com.google.gson.reflect.TypeToken
+
+# Reown (formerly WalletConnect) ProGuard rules
+-keep class com.reown.walletkit.client.Wallet$Model { *; }
+-keep class com.reown.walletkit.client.Wallet { *; }
+-keep class com.reown.android.** { *; }
+-dontwarn com.reown.**

--- a/app/src/main/java/jp/co/soramitsu/app/App.kt
+++ b/app/src/main/java/jp/co/soramitsu/app/App.kt
@@ -3,11 +3,11 @@ package jp.co.soramitsu.app
 import android.app.Application
 import android.content.Context
 import android.content.res.Configuration
-import com.walletconnect.android.Core
-import com.walletconnect.android.CoreClient
-import com.walletconnect.android.relay.ConnectionType
-import com.walletconnect.web3.wallet.client.Wallet
-import com.walletconnect.web3.wallet.client.Web3Wallet
+import com.reown.android.Core
+import com.reown.android.CoreClient
+import com.reown.android.relay.ConnectionType
+import com.reown.walletkit.client.Wallet
+import com.reown.walletkit.client.WalletKit
 import dagger.hilt.android.HiltAndroidApp
 import jp.co.soramitsu.common.BuildConfig
 import jp.co.soramitsu.common.data.network.OptionsProvider
@@ -67,7 +67,7 @@ open class App : Application() {
 
         val initParams = Wallet.Params.Init(core = CoreClient)
 
-        Web3Wallet.initialize(initParams) { error ->
+        WalletKit.initialize(initParams) { error ->
             // Error will be thrown if there's an issue during initialization
             error.throwable.printStackTrace()
         }

--- a/app/src/main/java/jp/co/soramitsu/app/root/domain/RootInteractor.kt
+++ b/app/src/main/java/jp/co/soramitsu/app/root/domain/RootInteractor.kt
@@ -1,6 +1,6 @@
 package jp.co.soramitsu.app.root.domain
 
-import com.walletconnect.web3.wallet.client.Web3Wallet
+import com.reown.walletkit.client.WalletKit
 import jp.co.soramitsu.wallet.impl.data.buyToken.ExternalProvider
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -11,5 +11,5 @@ class RootInteractor(
 
 
 
-    suspend fun getPendingListOfSessionRequests(topic: String) = withContext(Dispatchers.Default){ Web3Wallet.getPendingListOfSessionRequests(topic) }
+    suspend fun getPendingListOfSessionRequests(topic: String) = withContext(Dispatchers.Default){ WalletKit.getPendingListOfSessionRequests(topic) }
 }

--- a/app/src/main/java/jp/co/soramitsu/app/root/presentation/RootViewModel.kt
+++ b/app/src/main/java/jp/co/soramitsu/app/root/presentation/RootViewModel.kt
@@ -3,7 +3,7 @@ package jp.co.soramitsu.app.root.presentation
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.viewModelScope
-import com.walletconnect.web3.wallet.client.Wallet
+import com.reown.walletkit.client.Wallet
 import dagger.hilt.android.lifecycle.HiltViewModel
 import jp.co.soramitsu.app.R
 import jp.co.soramitsu.app.root.domain.AppInitializer

--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,8 @@ buildscript {
         targetSdkVersion = 35
 
         withoutBasic = { exclude group: 'jp.co.soramitsu.xnetworking', module: 'basic' }
+        // Closure to exclude JNA from 3rd party dependencies to prevent class duplication
+        // JNA is added as direct dependency where needed to avoid "missing class" errors
         withoutJna = { exclude group: 'net.java.dev.jna' }
         withoutJavaWS = { exclude module: 'java-websocket-lib' }
     }

--- a/feature-wallet-impl/build.gradle
+++ b/feature-wallet-impl/build.gradle
@@ -76,9 +76,10 @@ dependencies {
     implementation project(':feature-walletconnect-api')
     implementation project(':feature-tonconnect-api')
 
-    implementation platform(libs.walletconnectBomDep)
-    implementation libs.walletconnectCoreDep
-    implementation libs.walletconnectWeb3WalletDep
+    implementation platform(libs.reownBomDep)
+    // Exclude JNA from Reown libraries to prevent class duplication - using direct JNA dependency below
+    implementation libs.reownCoreDep, withoutJna
+    implementation libs.reownWalletKitDep, withoutJna
 
     implementation libs.kotlin.stdlib.jdk7
 
@@ -123,7 +124,9 @@ dependencies {
 
     implementation libs.insetter.widgets
 
+    // JNA is added as direct dependency to prevent class duplication from 3rd party libraries
     implementation libs.jna
+    // Exclude JNA from beacon SDK to prevent class duplication - using direct JNA dependency above
     implementation libs.beacon.android.sdk, withoutJna
 
 

--- a/feature-wallet-impl/src/main/java/jp/co/soramitsu/wallet/impl/presentation/balance/list/BalanceListViewModel.kt
+++ b/feature-wallet-impl/src/main/java/jp/co/soramitsu/wallet/impl/presentation/balance/list/BalanceListViewModel.kt
@@ -9,7 +9,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.viewModelScope
 import co.jp.soramitsu.walletconnect.domain.WalletConnectInteractor
-import com.walletconnect.android.internal.common.exception.MalformedWalletConnectUri
+import com.reown.android.internal.common.exception.MalformedWalletConnectUri
 import dagger.hilt.android.lifecycle.HiltViewModel
 import jp.co.soramitsu.account.api.domain.PendulumPreInstalledAccountsScenario
 import jp.co.soramitsu.account.api.domain.interfaces.AccountInteractor

--- a/feature-walletconnect-api/build.gradle.kts
+++ b/feature-walletconnect-api/build.gradle.kts
@@ -33,7 +33,13 @@ dependencies {
     implementation(libs.fragmentKtx)
     implementation(libs.material)
 
-    implementation(platform(libs.walletconnectBomDep))
-    implementation(libs.walletconnectCoreDep)
-    implementation(libs.walletconnectWeb3WalletDep)
+    implementation(platform(libs.reownBomDep))
+    implementation(libs.reownCoreDep) {
+        // Exclude JNA to prevent class duplication - JNA is added as direct dependency in app module
+        exclude(group = "net.java.dev.jna")
+    }
+    implementation(libs.reownWalletKitDep) {
+        // Exclude JNA to prevent class duplication - JNA is added as direct dependency in app module
+        exclude(group = "net.java.dev.jna")
+    }
 }

--- a/feature-walletconnect-api/src/main/java/co/jp/soramitsu/walletconnect/domain/WalletConnectInteractor.kt
+++ b/feature-walletconnect-api/src/main/java/co/jp/soramitsu/walletconnect/domain/WalletConnectInteractor.kt
@@ -1,6 +1,6 @@
 package co.jp.soramitsu.walletconnect.domain
 
-import com.walletconnect.web3.wallet.client.Wallet
+import com.reown.walletkit.client.Wallet
 import jp.co.soramitsu.core.models.ChainId
 import jp.co.soramitsu.runtime.multiNetwork.chain.model.Chain
 

--- a/feature-walletconnect-impl/build.gradle.kts
+++ b/feature-walletconnect-impl/build.gradle.kts
@@ -40,9 +40,15 @@ dependencies {
 
     implementation(libs.web3jDep)
 
-    implementation(platform(libs.walletconnectBomDep))
-    implementation(libs.walletconnectCoreDep)
-    implementation(libs.walletconnectWeb3WalletDep)
+    implementation(platform(libs.reownBomDep))
+    implementation(libs.reownCoreDep) {
+        // Exclude JNA to prevent class duplication - JNA is added as direct dependency in app module
+        exclude(group = "net.java.dev.jna")
+    }
+    implementation(libs.reownWalletKitDep) {
+        // Exclude JNA to prevent class duplication - JNA is added as direct dependency in app module
+        exclude(group = "net.java.dev.jna")
+    }
 
     implementation(libs.zxing.core)
     implementation(libs.zxing.embedded)

--- a/feature-walletconnect-impl/src/main/java/jp/co/soramitsu/walletconnect/impl/presentation/WCDelegate.kt
+++ b/feature-walletconnect-impl/src/main/java/jp/co/soramitsu/walletconnect/impl/presentation/WCDelegate.kt
@@ -1,9 +1,9 @@
 package jp.co.soramitsu.walletconnect.impl.presentation
 
-import com.walletconnect.android.Core
-import com.walletconnect.android.CoreClient
-import com.walletconnect.web3.wallet.client.Wallet
-import com.walletconnect.web3.wallet.client.Web3Wallet
+import com.reown.android.Core
+import com.reown.android.CoreClient
+import com.reown.walletkit.client.Wallet
+import com.reown.walletkit.client.WalletKit
 import jp.co.soramitsu.common.utils.Event
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -15,35 +15,26 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 
-object WCDelegate : Web3Wallet.WalletDelegate, CoreClient.CoreDelegate {
+object WCDelegate : WalletKit.WalletDelegate, CoreClient.CoreDelegate {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
     private val _walletEvents: MutableSharedFlow<Wallet.Model> = MutableSharedFlow()
     val walletEvents: SharedFlow<Wallet.Model> = _walletEvents.asSharedFlow()
-    var authRequestEvent: Pair<Wallet.Model.AuthRequest, Wallet.Model.VerifyContext>? = null
     var sessionProposalEvent: Pair<Wallet.Model.SessionProposal, Wallet.Model.VerifyContext>? = null
     var sessionRequestEvent: Pair<Wallet.Model.SessionRequest, Wallet.Model.VerifyContext>? = null
 
     init {
         CoreClient.setDelegate(this)
-        Web3Wallet.setWalletDelegate(this)
+        WalletKit.setWalletDelegate(this)
     }
 
     private val updateSessions = MutableStateFlow(Event(Unit))
     val activeSessionFlow = updateSessions.map {
-        Web3Wallet.getListOfActiveSessions()
+        WalletKit.getListOfActiveSessions()
     }
 
     fun refreshConnections() {
         updateSessions.value = Event(Unit)
-    }
-
-    override fun onAuthRequest(authRequest: Wallet.Model.AuthRequest, verifyContext: Wallet.Model.VerifyContext) {
-        authRequestEvent = Pair(authRequest, verifyContext)
-
-        scope.launch {
-            _walletEvents.emit(authRequest)
-        }
     }
 
     override fun onConnectionStateChange(state: Wallet.Model.ConnectionState) {

--- a/feature-walletconnect-impl/src/main/java/jp/co/soramitsu/walletconnect/impl/presentation/WCExt.kt
+++ b/feature-walletconnect-impl/src/main/java/jp/co/soramitsu/walletconnect/impl/presentation/WCExt.kt
@@ -1,8 +1,8 @@
 package jp.co.soramitsu.walletconnect.impl.presentation
 
 import androidx.core.net.toUri
-import com.walletconnect.android.Core
-import com.walletconnect.web3.wallet.client.Wallet
+import com.reown.android.Core
+import com.reown.walletkit.client.Wallet
 import io.ipfs.multibase.CharEncoding
 import jp.co.soramitsu.runtime.multiNetwork.chain.model.Chain
 import jp.co.soramitsu.shared_utils.extensions.fromHex

--- a/feature-walletconnect-impl/src/main/java/jp/co/soramitsu/walletconnect/impl/presentation/WalletConnectInteractorImpl.kt
+++ b/feature-walletconnect-impl/src/main/java/jp/co/soramitsu/walletconnect/impl/presentation/WalletConnectInteractorImpl.kt
@@ -1,11 +1,11 @@
 package jp.co.soramitsu.walletconnect.impl.presentation
 
 import co.jp.soramitsu.walletconnect.domain.WalletConnectInteractor
-import com.walletconnect.android.cacao.signature.SignatureType
-import com.walletconnect.android.utils.cacao.sign
-import com.walletconnect.web3.wallet.client.Wallet
-import com.walletconnect.web3.wallet.client.Web3Wallet
-import com.walletconnect.web3.wallet.utils.CacaoSigner
+import com.reown.android.cacao.signature.SignatureType
+import com.reown.android.utils.cacao.sign
+import com.reown.walletkit.client.Wallet
+import com.reown.walletkit.client.WalletKit
+import com.reown.walletkit.utils.CacaoSigner
 import jp.co.soramitsu.account.api.domain.interfaces.AccountRepository
 import jp.co.soramitsu.account.api.domain.model.MetaAccount
 import jp.co.soramitsu.account.api.domain.model.address
@@ -142,7 +142,7 @@ class WalletConnectInteractorImpl(
             )
         } + optionalSessionNamespaces.filter { it.key !in requiredSessionNamespaces.keys }
 
-        Web3Wallet.approveSession(
+        WalletKit.approveSession(
             params = Wallet.Params.SessionApprove(
                 proposerPublicKey = proposal.proposerPublicKey,
                 namespaces = sessionNamespaces,
@@ -158,7 +158,7 @@ class WalletConnectInteractorImpl(
         onSuccess: (Wallet.Params.SessionReject) -> Unit,
         onError: (Wallet.Model.Error) -> Unit
     ) {
-        Web3Wallet.rejectSession(
+        WalletKit.rejectSession(
             params = Wallet.Params.SessionReject(
                 proposal.proposerPublicKey,
                 "User rejected"
@@ -173,7 +173,7 @@ class WalletConnectInteractorImpl(
         onSuccess: (Wallet.Params.SessionReject) -> Unit,
         onError: (Wallet.Model.Error) -> Unit
     ) {
-        Web3Wallet.rejectSession(
+        WalletKit.rejectSession(
             params = Wallet.Params.SessionReject(
                 proposal.proposerPublicKey,
                 "Blockchain not supported by wallet"
@@ -215,7 +215,7 @@ class WalletConnectInteractorImpl(
             )
         }
 
-        Web3Wallet.respondSessionRequest(
+        WalletKit.respondSessionRequest(
             params = Wallet.Params.SessionRequestResponse(
                 sessionTopic = topic,
                 jsonRpcResponse = jsonRpcResponse
@@ -441,7 +441,7 @@ class WalletConnectInteractorImpl(
         onSuccess: (Wallet.Params.SessionRequestResponse) -> Unit,
         onError: (Wallet.Model.Error) -> Unit
     ) {
-        Web3Wallet.respondSessionRequest(
+        WalletKit.respondSessionRequest(
             params = Wallet.Params.SessionRequestResponse(
                 sessionTopic = sessionTopic,
                 jsonRpcResponse = Wallet.Model.JsonRpcResponse.JsonRpcError(
@@ -455,16 +455,16 @@ class WalletConnectInteractorImpl(
         )
     }
 
-    override fun getActiveSessionByTopic(topic: String) = Web3Wallet.getActiveSessionByTopic(topic)
+    override fun getActiveSessionByTopic(topic: String) = WalletKit.getActiveSessionByTopic(topic)
 
-    override fun getPendingListOfSessionRequests(topic: String) = Web3Wallet.getPendingListOfSessionRequests(topic)
+    override fun getPendingListOfSessionRequests(topic: String) = WalletKit.getPendingListOfSessionRequests(topic)
 
     override fun disconnectSession(
         topic: String,
         onSuccess: (Wallet.Params.SessionDisconnect) -> Unit,
         onError: (Wallet.Model.Error) -> Unit
     ) {
-        Web3Wallet.disconnectSession(
+        WalletKit.disconnectSession(
             params = Wallet.Params.SessionDisconnect(topic),
             onSuccess = {
                 WCDelegate.refreshConnections()
@@ -480,7 +480,7 @@ class WalletConnectInteractorImpl(
         onError: (Wallet.Model.Error) -> Unit
     ) {
         val pairingParams = Wallet.Params.Pair(pairingUri)
-        Web3Wallet.pair(
+        WalletKit.pair(
             params = pairingParams,
             onSuccess = onSuccess,
             onError = onError

--- a/feature-walletconnect-impl/src/main/java/jp/co/soramitsu/walletconnect/impl/presentation/connectioninfo/ConnectionInfoViewModel.kt
+++ b/feature-walletconnect-impl/src/main/java/jp/co/soramitsu/walletconnect/impl/presentation/connectioninfo/ConnectionInfoViewModel.kt
@@ -5,7 +5,7 @@ import androidx.lifecycle.viewModelScope
 import co.jp.soramitsu.feature_walletconnect_impl.R
 import co.jp.soramitsu.walletconnect.domain.WalletConnectInteractor
 import co.jp.soramitsu.walletconnect.domain.WalletConnectRouter
-import com.walletconnect.web3.wallet.client.Wallet
+import com.reown.walletkit.client.Wallet
 import dagger.hilt.android.lifecycle.HiltViewModel
 import jp.co.soramitsu.account.api.domain.interfaces.AccountRepository
 import jp.co.soramitsu.account.api.domain.model.address

--- a/feature-walletconnect-impl/src/main/java/jp/co/soramitsu/walletconnect/impl/presentation/connections/ConnectionsViewModel.kt
+++ b/feature-walletconnect-impl/src/main/java/jp/co/soramitsu/walletconnect/impl/presentation/connections/ConnectionsViewModel.kt
@@ -5,7 +5,7 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.viewModelScope
 import co.jp.soramitsu.feature_walletconnect_impl.R
 import co.jp.soramitsu.walletconnect.domain.WalletConnectInteractor
-import com.walletconnect.android.internal.common.exception.MalformedWalletConnectUri
+import com.reown.android.internal.common.exception.MalformedWalletConnectUri
 import dagger.hilt.android.lifecycle.HiltViewModel
 import jp.co.soramitsu.common.base.BaseViewModel
 import jp.co.soramitsu.common.resources.ResourceManager

--- a/feature-walletconnect-impl/src/main/java/jp/co/soramitsu/walletconnect/impl/presentation/requestpreview/RequestPreviewViewModel.kt
+++ b/feature-walletconnect-impl/src/main/java/jp/co/soramitsu/walletconnect/impl/presentation/requestpreview/RequestPreviewViewModel.kt
@@ -5,7 +5,7 @@ import androidx.lifecycle.viewModelScope
 import co.jp.soramitsu.feature_walletconnect_impl.R
 import co.jp.soramitsu.walletconnect.domain.WalletConnectInteractor
 import co.jp.soramitsu.walletconnect.domain.WalletConnectRouter
-import com.walletconnect.web3.wallet.client.Wallet
+import com.reown.walletkit.client.Wallet
 import dagger.hilt.android.lifecycle.HiltViewModel
 import jp.co.soramitsu.account.api.domain.interfaces.AccountRepository
 import jp.co.soramitsu.account.api.domain.model.address

--- a/feature-walletconnect-impl/src/main/java/jp/co/soramitsu/walletconnect/impl/presentation/sessionproposal/SessionProposalContent.kt
+++ b/feature-walletconnect-impl/src/main/java/jp/co/soramitsu/walletconnect/impl/presentation/sessionproposal/SessionProposalContent.kt
@@ -16,7 +16,7 @@ import androidx.compose.ui.platform.rememberNestedScrollInteropConnection
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.walletconnect.web3.wallet.client.Wallet
+import com.reown.walletkit.client.Wallet
 import jp.co.soramitsu.common.R
 import jp.co.soramitsu.common.compose.component.AccentButton
 import jp.co.soramitsu.common.compose.component.BottomSheetScreen

--- a/feature-walletconnect-impl/src/main/java/jp/co/soramitsu/walletconnect/impl/presentation/sessionproposal/SessionProposalViewModel.kt
+++ b/feature-walletconnect-impl/src/main/java/jp/co/soramitsu/walletconnect/impl/presentation/sessionproposal/SessionProposalViewModel.kt
@@ -5,7 +5,7 @@ import co.jp.soramitsu.feature_walletconnect_impl.R
 import co.jp.soramitsu.walletconnect.domain.WalletConnectInteractor
 import co.jp.soramitsu.walletconnect.domain.WalletConnectRouter
 import co.jp.soramitsu.walletconnect.model.ChainChooseResult
-import com.walletconnect.web3.wallet.client.Wallet
+import com.reown.walletkit.client.Wallet
 import dagger.hilt.android.lifecycle.HiltViewModel
 import jp.co.soramitsu.account.api.domain.interfaces.AccountRepository
 import jp.co.soramitsu.account.impl.presentation.account.mixin.api.AccountListingMixin

--- a/feature-walletconnect-impl/src/main/java/jp/co/soramitsu/walletconnect/impl/presentation/sessionrequest/WalletConnectSignMessageViewModel.kt
+++ b/feature-walletconnect-impl/src/main/java/jp/co/soramitsu/walletconnect/impl/presentation/sessionrequest/WalletConnectSignMessageViewModel.kt
@@ -5,7 +5,7 @@ import androidx.lifecycle.viewModelScope
 import co.jp.soramitsu.feature_walletconnect_impl.R
 import co.jp.soramitsu.walletconnect.domain.WalletConnectInteractor
 import co.jp.soramitsu.walletconnect.domain.WalletConnectRouter
-import com.walletconnect.web3.wallet.client.Wallet
+import com.reown.walletkit.client.Wallet
 import dagger.hilt.android.lifecycle.HiltViewModel
 import jp.co.soramitsu.account.api.domain.interfaces.AccountRepository
 import jp.co.soramitsu.account.api.domain.interfaces.TotalBalanceUseCase

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -60,7 +60,7 @@ sonarqubeGradlePlugin = "3.3"
 soraUiCore = "0.2.39"
 soraCard = "1.2.1-K2"
 storiesVersion = "3.0.1"
-walletconnectBom = "1.31.4"
+reownBom = "1.4.6"
 web3j = "4.8.8-android"
 wsVersion = "2.14"
 xNetworking = "1.0.13"
@@ -189,9 +189,9 @@ sharedFeaturesBackupDep = { module = "jp.co.soramitsu.shared_features:backup", v
 beacon-android-sdk = { module = "com.github.airgap-it:beacon-android-sdk", version.ref = "beaconVersion" }
 
 web3jDep = { module = "org.web3j:core", version.ref = "web3j" }
-walletconnectBomDep = { module = "com.walletconnect:android-bom", version.ref = "walletconnectBom" }
-walletconnectCoreDep = { module = "com.walletconnect:android-core" }
-walletconnectWeb3WalletDep = { module = "com.walletconnect:web3wallet" }
+reownBomDep = { module = "com.reown:android-bom", version.ref = "reownBom" }
+reownCoreDep = { module = "com.reown:android-core" }
+reownWalletKitDep = { module = "com.reown:walletkit" }
 
 jnr-x86asm = { module = "com.github.jnr:jnr-x86asm", version.ref = "jnrVersion" }
 


### PR DESCRIPTION
- Updated dependency references from walletconnect to reown v1.4.6
- Added ProGuard rules for Reown SDK compatibility
- Documented JNA exclusion to prevent class duplication conflicts
- Removed deprecated auth request functionality 

--- 
WalletConnect was deprecated: https://github.com/WalletConnect/WalletConnectKotlinV2/tree/develop?tab=readme-ov-file#deprecated---walletconnect---kotlin 

Migration guide:  https://docs.reown.com/walletkit/upgrade/from-web3wallet-android 
