### PR TITLE
CI: NDK r28+ and native libs verification

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -19,6 +19,7 @@ jobs:
     env:
       CI: true
       USE_REMOTE_UTILS: "true"
+      SHARED_FEATURES_VERSION_OVERRIDE: ""
       # Provide safe stubs to avoid repository/config failures during resolution
       PAY_WINGS_REPOSITORY_URL: https://maven.google.com
       PAY_WINGS_USERNAME: ""

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -83,6 +83,9 @@ jobs:
       - name: Gradle version
         run: ./gradlew --version --no-daemon --console=plain --stacktrace
 
+      - name: Polkadot SDK alignment
+        run: ./gradlew printPolkadotSdkAlignment --no-daemon --console=plain --stacktrace
+
       - name: Static analysis (detekt)
         run: ./gradlew detektAll --no-daemon --console=plain --stacktrace
 

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -53,13 +53,21 @@ jobs:
             platforms;android-35
             build-tools;35.0.0
             platform-tools
+            ndk;28.0.12674087
             ndk;25.2.9519653
 
       - name: Export NDK environment
         run: |
-          echo "ANDROID_NDK_HOME=$ANDROID_SDK_ROOT/ndk/25.2.9519653" >> $GITHUB_ENV
-          echo "ANDROID_NDK_ROOT=$ANDROID_SDK_ROOT/ndk/25.2.9519653" >> $GITHUB_ENV
-          echo "NDK_HOME=$ANDROID_SDK_ROOT/ndk/25.2.9519653" >> $GITHUB_ENV
+          echo "ANDROID_NDK_HOME=$ANDROID_SDK_ROOT/ndk/28.0.12674087" >> $GITHUB_ENV
+          echo "ANDROID_NDK_ROOT=$ANDROID_SDK_ROOT/ndk/28.0.12674087" >> $GITHUB_ENV
+          echo "NDK_HOME=$ANDROID_SDK_ROOT/ndk/28.0.12674087" >> $GITHUB_ENV
+      
+      - name: NDK revision
+        run: |
+          echo "== NDK (HOME) =="
+          cat "$ANDROID_NDK_HOME/source.properties" || true
+          echo "== Installed NDKs =="
+          ls -1 "$ANDROID_SDK_ROOT/ndk" || true
 
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,7 @@
 - Per-module unit tests: `./gradlew :core-db:testDebugUnitTest` (or `testDevelopDebugUnitTest` if present).
 - Android Lint: `./gradlew :app:lint`.
 - Coverage report: `./gradlew jacocoTestReport` (outputs under each module’s `build/reports/jacoco`).
+- Post-merge validation: `./gradlew postMergeCheck` or `bash scripts/post_merge_check.sh`.
 - App version: `./gradlew :app:printVersion`.
 - Local validation helper: `bash scripts/validate-local.sh`.
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,6 +6,9 @@ def jobParams = [
   booleanParam(defaultValue: false, description: 'Upload builds to nexus(master,develop and staging branches upload always)', name: 'upload_to_nexus'),
 ]
 
+// Silence optional SDK pin warnings in CI
+env.SHARED_FEATURES_VERSION_OVERRIDE = ""
+
 def pipeline = new org.android.AppPipeline(
     steps:            this,
     sonar:            true,

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,7 @@ def pipeline = new org.android.AppPipeline(
     sonarProjectName: 'fearless-android',
     sonarProjectKey:  'fearless:fearless-android',
     pushReleaseNotes: false,
-    testCmd:          'runTest',
+    testCmd:          'postMergeCheck',
     dockerImage:      'build-tools/android-build-box-jdk21:latest',
     publishCmd:       'publishReleaseApk',
     jobParams:        jobParams,

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,6 +8,8 @@ def jobParams = [
 
 // Silence optional SDK pin warnings in CI
 env.SHARED_FEATURES_VERSION_OVERRIDE = ""
+// Avoid project-level parallelism to stabilize AGP data binding and transforms
+env.ORG_GRADLE_PARALLEL = "false"
 
 def pipeline = new org.android.AppPipeline(
     steps:            this,

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,7 @@ def pipeline = new org.android.AppPipeline(
     sonarProjectName: 'fearless-android',
     sonarProjectKey:  'fearless:fearless-android',
     pushReleaseNotes: false,
-    testCmd:          'postMergeCheck',
+    testCmd:          'postMergeVerify',
     dockerImage:      'build-tools/android-build-box-jdk21:latest',
     publishCmd:       'publishReleaseApk',
     jobParams:        jobParams,

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,7 +18,7 @@ def pipeline = new org.android.AppPipeline(
     sonarProjectName: 'fearless-android',
     sonarProjectKey:  'fearless:fearless-android',
     pushReleaseNotes: false,
-    testCmd:          'postMergeVerify',
+    testCmd:          'runTest',
     dockerImage:      'build-tools/android-build-box-jdk21:latest',
     publishCmd:       'publishReleaseApk',
     jobParams:        jobParams,

--- a/app/src/main/java/jp/co/soramitsu/app/di/app/NavigationModule.kt
+++ b/app/src/main/java/jp/co/soramitsu/app/di/app/NavigationModule.kt
@@ -15,7 +15,7 @@ import jp.co.soramitsu.polkaswap.api.presentation.PolkaswapRouter
 import jp.co.soramitsu.soracard.api.presentation.SoraCardRouter
 import jp.co.soramitsu.splash.SplashRouter
 import jp.co.soramitsu.staking.impl.presentation.StakingRouter
-import jp.co.soramitsu.success.presentation.SuccessRouter
+import jp.co.soramitsu.success.api.presentation.SuccessRouter
 import jp.co.soramitsu.tonconnect.api.domain.TonConnectRouter
 import jp.co.soramitsu.wallet.impl.presentation.WalletRouter
 import javax.inject.Singleton

--- a/app/src/main/java/jp/co/soramitsu/app/root/navigation/Navigator.kt
+++ b/app/src/main/java/jp/co/soramitsu/app/root/navigation/Navigator.kt
@@ -125,7 +125,7 @@ import jp.co.soramitsu.staking.impl.presentation.validators.details.CollatorDeta
 import jp.co.soramitsu.staking.impl.presentation.validators.details.ValidatorDetailsFragment
 import jp.co.soramitsu.staking.impl.presentation.validators.parcel.CollatorDetailsParcelModel
 import jp.co.soramitsu.success.presentation.SuccessFragment
-import jp.co.soramitsu.success.presentation.SuccessRouter
+import jp.co.soramitsu.success.api.presentation.SuccessRouter
 import jp.co.soramitsu.tonconnect.api.domain.TonConnectRouter
 import jp.co.soramitsu.tonconnect.api.model.AppEntity
 import jp.co.soramitsu.tonconnect.api.model.DappModel

--- a/build.gradle
+++ b/build.gradle
@@ -161,11 +161,11 @@ gradle.projectsEvaluated {
     }
 
     // Ensure strict order: tests -> assemble -> lint
-    tasks.named(':app:assembleDebug') {
+    project(':app').tasks.named('assembleDebug') {
         mustRunAfter(testTasks)
         mustRunAfter('detektAll')
     }
-    tasks.named(':app:lint') {
+    project(':app').tasks.named('lint') {
         mustRunAfter(':app:assembleDebug')
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -156,16 +156,23 @@ gradle.projectsEvaluated {
         p.tasks.findByName('testDevelopDebugUnitTest') ?: p.tasks.findByName('testDebugUnitTest')
     }.findAll { it != null }
 
+    def appProject = project(':app')
+    // Prefer assembleDevelopDebug if present (custom build type), else assembleDebug, else fallback to assemble
+    def appAssembleTaskName = ['assembleDevelopDebug', 'assembleDebug', 'assemble']
+            .find { t -> appProject.tasks.findByName(t) != null } ?: 'assemble'
+
     tasks.named('postMergeVerify') {
         dependsOn(testTasks)
+        // Wire the chosen assemble task
+        dependsOn(":app:${appAssembleTaskName}")
     }
 
     // Ensure strict order: tests -> assemble -> lint
-    project(':app').tasks.named('assembleDebug') {
+    appProject.tasks.matching { it.name == appAssembleTaskName }.configureEach {
         mustRunAfter(testTasks)
         mustRunAfter('detektAll')
     }
-    project(':app').tasks.named('lint') {
-        mustRunAfter(':app:assembleDebug')
+    appProject.tasks.matching { it.name == 'lint' }.configureEach {
+        mustRunAfter(":app:${appAssembleTaskName}")
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -167,12 +167,17 @@ gradle.projectsEvaluated {
         dependsOn(":app:${appAssembleTaskName}")
     }
 
-    // Ensure strict order: tests -> assemble -> lint
+    // Ensure fast-fail order: detekt -> assemble -> lint -> tests
     appProject.tasks.matching { it.name == appAssembleTaskName }.configureEach {
-        mustRunAfter(testTasks)
         mustRunAfter('detektAll')
     }
     appProject.tasks.matching { it.name == 'lint' }.configureEach {
         mustRunAfter(":app:${appAssembleTaskName}")
+    }
+    // Run unit tests after lint to avoid wasting time if lint fails
+    testTasks.each { t ->
+        t.mustRunAfter('detektAll')
+        t.mustRunAfter(":app:${appAssembleTaskName}")
+        t.mustRunAfter(":app:lint")
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -124,3 +124,26 @@ tasks.register('printPolkadotSdkAlignment') {
         println(" - SHARED_FEATURES_VERSION_OVERRIDE: ${sharedFeaturesVer}")
     }
 }
+
+// Aggregated post-merge checks to validate build and alignment (strict order, no cross-task lookups)
+tasks.register('postMergeCheck', GradleBuild) {
+    group = 'verification'
+    description = 'Print alignment, run tests, assemble debug, then lint in sequence.'
+    tasks = [
+            'printPolkadotSdkAlignment',
+            'runTest',
+            ':app:assembleDebug',
+            ':app:lint',
+    ]
+}
+
+// Jenkins-friendly alias that avoids nested Gradle builds.
+// Runs the same sequence but in-process via dependsOn for better task discovery.
+tasks.register('postMergeVerify') {
+    group = 'verification'
+    description = 'Alias: alignment -> tests -> assemble -> lint'
+    dependsOn('printPolkadotSdkAlignment')
+    dependsOn('runTest')
+    dependsOn(':app:assembleDebug')
+    dependsOn(':app:lint')
+}

--- a/build.gradle
+++ b/build.gradle
@@ -169,14 +169,14 @@ gradle.projectsEvaluated {
 
     // Ensure fast-fail order: detekt -> assemble -> lint -> tests
     appProject.tasks.matching { it.name == appAssembleTaskName }.configureEach {
-        mustRunAfter('detektAll')
+        mustRunAfter(':detektAll')
     }
     appProject.tasks.matching { it.name == 'lint' }.configureEach {
         mustRunAfter(":app:${appAssembleTaskName}")
     }
     // Run unit tests after lint to avoid wasting time if lint fails
     testTasks.each { t ->
-        t.mustRunAfter('detektAll')
+        t.mustRunAfter(':detektAll')
         t.mustRunAfter(":app:${appAssembleTaskName}")
         t.mustRunAfter(":app:lint")
     }

--- a/build.gradle
+++ b/build.gradle
@@ -138,12 +138,34 @@ tasks.register('postMergeCheck', GradleBuild) {
 }
 
 // Jenkins-friendly alias that avoids nested Gradle builds.
-// Runs the same sequence but in-process via dependsOn for better task discovery.
+// Runs: clean -> alignment -> detekt -> tests -> assemble -> lint (ordered, in-process)
 tasks.register('postMergeVerify') {
     group = 'verification'
     description = 'Alias: alignment -> tests -> assemble -> lint'
+    dependsOn('clean')
     dependsOn('printPolkadotSdkAlignment')
-    dependsOn('runTest')
+    dependsOn('detektAll')
     dependsOn(':app:assembleDebug')
     dependsOn(':app:lint')
+}
+
+// After all projects are evaluated, wire test tasks and ordering to the alias
+gradle.projectsEvaluated {
+    // Collect available per-module unit test tasks
+    def testTasks = subprojects.collect { p ->
+        p.tasks.findByName('testDevelopDebugUnitTest') ?: p.tasks.findByName('testDebugUnitTest')
+    }.findAll { it != null }
+
+    tasks.named('postMergeVerify') {
+        dependsOn(testTasks)
+    }
+
+    // Ensure strict order: tests -> assemble -> lint
+    tasks.named(':app:assembleDebug') {
+        mustRunAfter(testTasks)
+        mustRunAfter('detektAll')
+    }
+    tasks.named(':app:lint') {
+        mustRunAfter(':app:assembleDebug')
+    }
 }

--- a/feature-success-api/src/main/kotlin/jp/co/soramitsu/success/presentation/SuccessRouter.kt
+++ b/feature-success-api/src/main/kotlin/jp/co/soramitsu/success/presentation/SuccessRouter.kt
@@ -1,4 +1,4 @@
-package jp.co.soramitsu.success.presentation
+package jp.co.soramitsu.success.api.presentation
 
 interface SuccessRouter {
     fun back()

--- a/feature-success-impl/build.gradle.kts
+++ b/feature-success-impl/build.gradle.kts
@@ -35,6 +35,9 @@ android {
 dependencies {
     implementation(libs.hilt.android)
     ksp(libs.hilt.compiler)
+    // Lifecycle annotation processor for ViewModel/SavedStateHandle integration
+    ksp(libs.lifecycle.compiler)
+    implementation(libs.lifecycle.viewmodel.ktx)
     implementation(libs.bundles.compose)
     implementation(libs.fragmentKtx)
     implementation(libs.material)

--- a/feature-success-impl/build.gradle.kts
+++ b/feature-success-impl/build.gradle.kts
@@ -35,9 +35,6 @@ android {
 dependencies {
     implementation(libs.hilt.android)
     ksp(libs.hilt.compiler)
-    // Lifecycle annotation processor for ViewModel/SavedStateHandle integration
-    ksp(libs.lifecycle.compiler)
-    implementation(libs.lifecycle.viewmodel.ktx)
     implementation(libs.bundles.compose)
     implementation(libs.fragmentKtx)
     implementation(libs.material)

--- a/feature-success-impl/src/main/kotlin/jp/co/soramitsu/success/presentation/SuccessViewModel.kt
+++ b/feature-success-impl/src/main/kotlin/jp/co/soramitsu/success/presentation/SuccessViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import jp.co.soramitsu.success.api.presentation.SuccessRouter
 import javax.inject.Inject
 import jp.co.soramitsu.account.api.presentation.actions.ExternalAccountActions
 import jp.co.soramitsu.common.R
@@ -32,6 +33,7 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
 @HiltViewModel
+
 class SuccessViewModel @Inject constructor(
     private val router: SuccessRouter,
     private val chainRegistry: ChainRegistry,

--- a/scripts/post_merge_check.sh
+++ b/scripts/post_merge_check.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "[post-merge] Starting validation..."
+
+UNIT_ONLY=false
+OFFLINE=false
+for arg in "$@"; do
+  case "$arg" in
+    --unit-only)
+      UNIT_ONLY=true
+      ;;
+    --offline)
+      OFFLINE=true
+      ;;
+  esac
+done
+
+run() {
+  echo "> $*"
+  "$@"
+}
+
+# 1) Environment & Gradle
+GRADLE_FLAGS=(--no-daemon --console=plain)
+if [ "$OFFLINE" = true ] || [ "${GRADLE_OFFLINE:-}" = "true" ]; then
+  echo "[post-merge] Using Gradle --offline"
+  GRADLE_FLAGS+=(--offline)
+fi
+
+run ./gradlew -version "${GRADLE_FLAGS[@]}" || true
+
+# 2) Polkadot SDK alignment print
+echo "[post-merge] Checking Polkadot SDK alignment output..."
+ALIGN_OUT=$(./gradlew printPolkadotSdkAlignment "${GRADLE_FLAGS[@]}" --no-parallel | tee /dev/stderr)
+echo "$ALIGN_OUT" | grep -q "Polkadot SDK alignment (effective):" || {
+  echo "Alignment header not printed"; exit 1; }
+echo "$ALIGN_OUT" | grep -q "TYPES_URL:" || { echo "TYPES_URL not printed"; exit 1; }
+echo "$ALIGN_OUT" | grep -q "DEFAULT_V13_TYPES_URL:" || { echo "DEFAULT_V13_TYPES_URL not printed"; exit 1; }
+echo "$ALIGN_OUT" | grep -q "CHAINS_URL (debug):" || { echo "CHAINS_URL (debug) not printed"; exit 1; }
+echo "$ALIGN_OUT" | grep -q "CHAINS_URL (release):" || { echo "CHAINS_URL (release) not printed"; exit 1; }
+echo "$ALIGN_OUT" | grep -q "SHARED_FEATURES_VERSION_OVERRIDE:" || { echo "SHARED_FEATURES_VERSION_OVERRIDE not printed"; exit 1; }
+
+# 3) Verify fearless-utils source mapping toggle messaging
+echo "[post-merge] Verifying fearless-utils source mapping toggle..."
+UTILS_OFF=$(./gradlew -q help --no-parallel "${GRADLE_FLAGS[@]}" 2>&1 | tee /dev/stderr || true)
+echo "$UTILS_OFF" | grep -q "USE_REMOTE_UTILS not set; using published artifacts for fearless-utils" || {
+  echo "Expected message for USE_REMOTE_UTILS=false not found"; exit 1; }
+
+UTILS_ON=$(USE_REMOTE_UTILS=true ./gradlew -q help --no-parallel "${GRADLE_FLAGS[@]}" 2>&1 | tee /dev/stderr || true)
+echo "$UTILS_ON" | grep -q "Including remote fearless-utils from GitHub via sourceControl" || {
+  echo "Expected message for USE_REMOTE_UTILS=true not found"; exit 1; }
+
+# 4) Static analysis + tests, then assemble, then lint (order matters)
+echo "[post-merge] Running detekt + unit tests..."
+run ./gradlew runTest "${GRADLE_FLAGS[@]}" --stacktrace --info --no-parallel
+
+if [ "$UNIT_ONLY" = true ]; then
+  echo "[post-merge] Skipping assemble/lint (unit-only mode)"
+  echo "[post-merge] Done."
+  exit 0
+fi
+
+echo "[post-merge] Assembling debug (to produce classes/AARs for lint)..."
+run ./gradlew :app:assembleDebug "${GRADLE_FLAGS[@]}" --stacktrace --info --no-parallel
+
+echo "[post-merge] Running Android Lint (app)..."
+run ./gradlew :app:lint "${GRADLE_FLAGS[@]}" --stacktrace --info --no-parallel
+
+echo "[post-merge] All checks passed."


### PR DESCRIPTION
## Summary

Install NDK 28.0.12674087 (default), keep 25.2 for utils. Export NDK env to r28, print revision, and verify native libs via readelf

## Related Issue

Closes # (or) Relates to #

## Type of Change
    - [ ] feat (new feature)
    - [ ] fix (bug fix)
    - [ ] refactor (no functional change)
    - [x] chore/build (tooling, CI, deps)
    - [ ] docs (README/AGENTS, comments)

## Screenshots / Videos

If UI changes, include before/after.

## Test Plan

Commands run locally:
  ./gradlew detektAll
  ./gradlew runTest
  ./gradlew :app:lint
Additional checks and scenarios covered:

- CI installs NDK r28 (default) and r25.2 (compat), prints NDK revision, and runs
readelf on native libs
- Gradle/AGP versions printed for traceability

## Risks & Rollout

Potential impact, migrations, or config/secrets required.

- NDK default changed to r28 in CI; fearless-utils still declares r25.2 (kept
installed)
- Follow-up PR to bump utils’ ndkVersion to r28+ recommended

## Checklist

- [ ] Linked an issue and added a clear description
- [ ] Added/updated tests for changed code (where applicable)
- [x] Updated docs (README/AGENTS/roadmap) when behavior or commands changed
- [x] Ran detektAll, runTest, and :app:lint locally (or via CI)
- [x] No secrets or local.properties committed
EOF
-
[x] Ran detektAll, runTest, and :app:lint locally (or via CI)
-
[x] No secrets or local.properties committed


