### PR TITLE
Bind XCM evidence to Android release commit

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -184,6 +184,9 @@ jobs:
       - name: Gradle version
         run: ./gradlew --version --no-daemon --console=plain --stacktrace
 
+      - name: Fearless-utils composite defaults
+        run: ./scripts/test-fearless-utils-composite-default.sh
+
       - name: Polkadot SDK alignment
         run: ./gradlew printPolkadotSdkAlignment --no-daemon --console=plain --stacktrace
 

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -57,8 +57,12 @@ procedure.
   `scripts/xcm-production-evidence.json` to
   `status: ready`, set `releaseEnabled: true`, remove every discovery-only
   route gap, attach E2E transfer evidence for every route in
-  `scripts/xcm-required-routes.tsv`, and run
+  `scripts/xcm-required-routes.tsv`, set each evidence record `androidCommit`
+  to the Android release commit under validation, and run
   `bash ./scripts/audit-xcm-production-evidence.sh --require-ready`.
+  For validating a tagged release from a different checkout, set
+  `XCM_PRODUCTION_EXPECTED_COMMIT` to the intended 40-character Android commit
+  when running the audit.
 - Run `bash ./scripts/check-iroha-mobile-sdk-release-assets.sh --self-test`.
   If `IROHA_MOBILE_SDK_RELEASE_TAG` is configured for the release, also run
   `bash ./scripts/check-iroha-mobile-sdk-release-assets.sh --download --tag "$IROHA_MOBILE_SDK_RELEASE_TAG"`.

--- a/runtime/src/main/java/jp/co/soramitsu/runtime/multiNetwork/runtime/RuntimeProvider.kt
+++ b/runtime/src/main/java/jp/co/soramitsu/runtime/multiNetwork/runtime/RuntimeProvider.kt
@@ -9,7 +9,9 @@ import jp.co.soramitsu.runtime.multiNetwork.ChainsStateTracker
 import jp.co.soramitsu.runtime.multiNetwork.chain.model.Chain
 import jp.co.soramitsu.runtime.multiNetwork.chain.model.reefChainId
 import jp.co.soramitsu.fearless_utils.runtime.RuntimeSnapshot
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
@@ -17,11 +19,10 @@ import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
 
@@ -31,8 +32,9 @@ class RuntimeProvider(
     private val runtimeFilesCache: RuntimeFilesCache,
     private val chainDao: ChainDao,
     private val networkStateService: NetworkStateService,
-    private val chain: Chain
-) : CoroutineScope by CoroutineScope(Dispatchers.Default) {
+    private val chain: Chain,
+    coroutineDispatcher: CoroutineDispatcher = Dispatchers.Default
+) : CoroutineScope by CoroutineScope(coroutineDispatcher) {
 
     private val chainId = chain.id
 
@@ -79,9 +81,11 @@ class RuntimeProvider(
     } ?: flowOf(Result.failure(Throwable("Timeout")))
 
     init {
-        runtimeSyncService.syncResultFlow(chainId)
-            .onEach(::considerReconstructingRuntime)
-            .launchIn(this)
+        // Subscribe before initialization can yield so early sync results are not dropped.
+        launch(start = CoroutineStart.UNDISPATCHED) {
+            runtimeSyncService.syncResultFlow(chainId)
+                .collect(::considerReconstructingRuntime)
+        }
 
         tryLoadFromCache()
     }

--- a/runtime/src/test/java/jp/co/soramitsu/runtime/multiNetwork/runtime/RuntimeProviderTest.kt
+++ b/runtime/src/test/java/jp/co/soramitsu/runtime/multiNetwork/runtime/RuntimeProviderTest.kt
@@ -11,10 +11,14 @@ import jp.co.soramitsu.testshared.any
 import jp.co.soramitsu.testshared.eq
 import jp.co.soramitsu.testshared.thenThrowUnsafe
 import jp.co.soramitsu.testshared.whenever
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestCoroutineScheduler
 import kotlinx.coroutines.withTimeout
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -75,6 +79,25 @@ class RuntimeProviderTest {
             whenever(runtimeFilesCache.getChainMetadata(any())).thenReturn("metadata")
             whenever(chainDao.getTypes(any())).thenReturn("types")
         }
+    }
+
+    @Test
+    fun `should handle sync event emitted immediately after construction`() {
+        val testScheduler = TestCoroutineScheduler()
+        chainSyncFlow = MutableSharedFlow(extraBufferCapacity = 1)
+        currentChainTypesHash("Hash")
+        currentMetadataHash("Hash")
+
+        initProvider(StandardTestDispatcher(testScheduler))
+        chainSyncFlow.tryEmit(
+            SyncResult(chain.id, metadataHash = "Hash Changed", typesHash = "Hash")
+        )
+
+        testScheduler.advanceUntilIdle()
+
+        verify(runtimeFactory, times(2)).constructRuntime(any(), any(), anyInt())
+
+        runtimeProvider.finish()
     }
 
     @Test
@@ -216,14 +239,15 @@ class RuntimeProviderTest {
         whenever(constructedRuntime.ownTypesHash).thenReturn(hash)
     }
 
-    private fun initProvider() {
+    private fun initProvider(coroutineDispatcher: CoroutineDispatcher = Dispatchers.Default) {
         runtimeProvider = RuntimeProvider(
             runtimeFactory,
             runtimeSyncService,
             runtimeFilesCache,
             chainDao,
             networkStateService,
-            chain
+            chain,
+            coroutineDispatcher
         )
     }
 }

--- a/runtime/src/test/java/jp/co/soramitsu/runtime/multiNetwork/runtime/RuntimeProviderTest.kt
+++ b/runtime/src/test/java/jp/co/soramitsu/runtime/multiNetwork/runtime/RuntimeProviderTest.kt
@@ -202,7 +202,7 @@ class RuntimeProviderTest {
         val verification = if (times == 0) {
             after(100).times(expectedCalls)
         } else {
-            timeout(1_000).times(expectedCalls)
+            timeout(5_000).times(expectedCalls)
         }
 
         verify(runtimeFactory, verification).constructRuntime(any(), any(), anyInt())

--- a/scripts/audit-xcm-production-evidence.sh
+++ b/scripts/audit-xcm-production-evidence.sh
@@ -14,6 +14,8 @@ Usage: scripts/audit-xcm-production-evidence.sh [--evidence <path>] [--required-
 Validates the Android XCM production evidence manifest. The default audit allows
 the current blocked state, but rejects any release-enabled or ready claim unless
 all required route evidence is present and no discovery-only XCM gaps remain.
+Ready evidence must also record androidCommit for every route and match it to
+XCM_PRODUCTION_EXPECTED_COMMIT when set, otherwise the local Android git HEAD.
 
 --require-ready additionally fails unless the manifest is marked ready for broad
 production XCM release.
@@ -58,13 +60,15 @@ if ! command -v node >/dev/null 2>&1; then
   exit 1
 fi
 
-node - "$EVIDENCE_FILE" "$REQUIRED_ROUTE_FILE" "$DISCOVERY_GAP_FILE" "$REQUIRE_READY" <<'NODE'
+node - "$ROOT_DIR" "$EVIDENCE_FILE" "$REQUIRED_ROUTE_FILE" "$DISCOVERY_GAP_FILE" "$REQUIRE_READY" <<'NODE'
+const childProcess = require('child_process');
 const fs = require('fs');
 
-const [evidenceFile, requiredRouteFile, discoveryGapFile, requireReadyRaw] = process.argv.slice(2);
+const [rootDir, evidenceFile, requiredRouteFile, discoveryGapFile, requireReadyRaw] = process.argv.slice(2);
 const requireReady = requireReadyRaw === 'true';
 const errors = [];
 const MAX_CLOCK_SKEW_MS = 5 * 60 * 1000;
+const EXPECTED_ANDROID_COMMIT_ENV = 'XCM_PRODUCTION_EXPECTED_COMMIT';
 
 const REQUIRED_BLOCKERS = [
   'e2e-transfer-evidence-missing',
@@ -82,7 +86,8 @@ const REQUIRED_EVIDENCE_FIELDS = [
   'amount',
   'timestamp',
   'environment',
-  'operator'
+  'operator',
+  'androidCommit'
 ];
 
 const ALLOWED_MANIFEST_FIELDS = [
@@ -172,9 +177,41 @@ function isRepeatedHexPlaceholder(value) {
   return /^[0-9a-f]{8,}$/.test(normalized) && new Set(normalized).size === 1;
 }
 
+function isGitCommit(value) {
+  return /^[0-9a-fA-F]{40}$/.test(String(value || '').trim());
+}
+
 function isPlaceholderText(value) {
   const normalized = String(value || '').trim().toLowerCase();
   return /^(todo|tbd|placeholder|example|sample|dummy|unknown|n\/a)(?:$|[_\-\s:])/u.test(normalized);
+}
+
+function resolveExpectedAndroidCommit(readyClaimed) {
+  const override = process.env[EXPECTED_ANDROID_COMMIT_ENV];
+  if (override !== undefined && override.trim().length > 0) {
+    if (!isGitCommit(override)) {
+      fail(`${EXPECTED_ANDROID_COMMIT_ENV} must be a 40-character git commit`);
+      return null;
+    }
+    return override.trim().toLowerCase();
+  }
+
+  try {
+    const commit = childProcess.execFileSync('git', ['-C', rootDir, 'rev-parse', 'HEAD'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore']
+    }).trim();
+    if (!isGitCommit(commit)) {
+      fail('git -C root rev-parse HEAD did not return a 40-character Android release commit');
+      return null;
+    }
+    return commit.toLowerCase();
+  } catch (error) {
+    if (readyClaimed) {
+      fail('ready XCM production evidence requires XCM_PRODUCTION_EXPECTED_COMMIT or a local Android git HEAD source');
+    }
+    return null;
+  }
 }
 
 function isIsoUtcSecond(value) {
@@ -412,6 +449,7 @@ if (manifest) {
   }
 
   const readyClaimed = manifest.status === 'ready' || manifest.releaseEnabled || requireReady;
+  const expectedAndroidCommit = readyClaimed ? resolveExpectedAndroidCommit(readyClaimed) : null;
   const evidenceByRoute = new Map();
   const requiredRouteKeys = new Set(requiredRoutes.map(routeKey));
   const extrinsicHashes = new Set();
@@ -484,6 +522,18 @@ if (manifest) {
     }
     if (isPlaceholderText(entry.operator)) {
       fail(`evidence[${index}].operator must not be a placeholder operator`);
+    }
+
+    if (!isGitCommit(entry.androidCommit)) {
+      fail(`evidence[${index}].androidCommit must be a 40-character git commit`);
+    } else {
+      const normalizedAndroidCommit = String(entry.androidCommit).trim().toLowerCase();
+      if (isRepeatedHexPlaceholder(normalizedAndroidCommit)) {
+        fail(`evidence[${index}].androidCommit must not be a placeholder Android release commit`);
+      }
+      if (readyClaimed && expectedAndroidCommit && normalizedAndroidCommit !== expectedAndroidCommit) {
+        fail(`evidence[${index}].androidCommit must match expected Android release commit ${expectedAndroidCommit}`);
+      }
     }
   });
 

--- a/scripts/fearless-utils-library-only.patch
+++ b/scripts/fearless-utils-library-only.patch
@@ -17,20 +17,22 @@ index 20a5d27..b66ede9 100644
      }
  }
 diff --git a/fearless-utils/build.gradle b/fearless-utils/build.gradle
-index 299edac..c97da66 100644
+index 299edac..d7adf31 100644
 --- a/fearless-utils/build.gradle
 +++ b/fearless-utils/build.gradle
-@@ -2,9 +2,18 @@ apply plugin: 'com.android.library'
+@@ -2,9 +2,20 @@ apply plugin: 'com.android.library'
  apply plugin: 'kotlin-android'
  apply plugin: 'kotlin-kapt'
  apply plugin: 'kotlinx-serialization'
 -apply plugin: 'org.mozilla.rust-android-gradle.rust-android'
  apply from: '../maven-publish-helper.gradle'
  
++def libraryOnlyOverride = System.getenv("FEARLESS_UTILS_LIBRARY_ONLY")
++def compositeLibraryOnly = libraryOnlyOverride == null && gradle.parent != null
 +def skipRustPlugin = (
 +        System.getenv("FEARLESS_UTILS_SKIP_RUST_PLUGIN")
-+                ?: System.getenv("FEARLESS_UTILS_LIBRARY_ONLY")
-+                ?: "false"
++                ?: libraryOnlyOverride
++                ?: compositeLibraryOnly.toString()
 +).toBoolean()
 +
 +if (!skipRustPlugin) {
@@ -40,7 +42,7 @@ index 299edac..c97da66 100644
  publishing {
      publications {
          release(MavenPublication) {
-@@ -51,16 +60,24 @@ android {
+@@ -51,16 +62,24 @@ android {
      namespace 'jp.co.soramitsu.fearless_utils'
  }
  
@@ -73,7 +75,7 @@ index 299edac..c97da66 100644
      }
  }
  
-@@ -78,14 +95,12 @@ task createJar(type: Copy) {
+@@ -78,14 +97,12 @@ task createJar(type: Copy) {
  createJar.dependsOn(deleteJar, build)
  
  dependencies {
@@ -315,16 +317,22 @@ index 73ce3ad..f8c7b53 100644
  
      private fun isSubscriptionChange(string: String): Boolean {
 diff --git a/settings.gradle b/settings.gradle
-index cf3e82f..9637431 100644
+index cf3e82f..a9e2e3d 100644
 --- a/settings.gradle
 +++ b/settings.gradle
-@@ -54,5 +54,9 @@ if (dependencySubstitutionsClass != null && !dependencySubstitutionsClass.metaCl
+@@ -54,5 +54,15 @@ if (dependencySubstitutionsClass != null && !dependencySubstitutionsClass.metaCl
  }
  
  include ':fearless-utils'
 -include ':app'
 +
-+def libraryOnly = (System.getenv("FEARLESS_UTILS_LIBRARY_ONLY") ?: "false").toBoolean()
++// Composite consumers substitute only the library. Avoid configuring the sample
++// app unless a standalone build or an explicit environment override requests it.
++def libraryOnlyOverride = System.getenv("FEARLESS_UTILS_LIBRARY_ONLY")
++def libraryOnly = libraryOnlyOverride == null
++        ? gradle.parent != null
++        : libraryOnlyOverride.toBoolean()
++
 +if (!libraryOnly) {
 +    include ':app'
 +}

--- a/scripts/generate-xcm-production-evidence-template.sh
+++ b/scripts/generate-xcm-production-evidence-template.sh
@@ -63,7 +63,8 @@ const REQUIRED_EVIDENCE_FIELDS = [
   'amount',
   'timestamp',
   'environment',
-  'operator'
+  'operator',
+  'androidCommit'
 ];
 
 function fail(message) {
@@ -131,6 +132,7 @@ if (!fs.existsSync(requiredRouteFile)) {
       instructions: [
         'Copy the evidence array into scripts/xcm-production-evidence.json only after replacing every TODO value.',
         'Do not include private keys, mnemonics, seeds, passwords, credentials, or authorization headers in public evidence.',
+        'Set androidCommit to the Android release commit under validation; for tagged release validation you may set XCM_PRODUCTION_EXPECTED_COMMIT when running the audit.',
         'After every route has evidence and no discovery-only gaps remain, set status to ready, releaseEnabled to true, clear blockers, and run bash ./scripts/audit-xcm-production-evidence.sh --require-ready.'
       ],
       requiredEvidenceFields: REQUIRED_EVIDENCE_FIELDS,
@@ -144,7 +146,8 @@ if (!fs.existsSync(requiredRouteFile)) {
         amount: 'TODO_positive_decimal_amount',
         timestamp: 'TODO_YYYY-MM-DDTHH:MM:SSZ',
         environment: 'mainnet',
-        operator: 'TODO_operator_or_runbook_id'
+        operator: 'TODO_operator_or_runbook_id',
+        androidCommit: 'TODO_android_release_commit'
       }))
     };
 

--- a/scripts/test-fearless-utils-composite-default.sh
+++ b/scripts/test-fearless-utils-composite-default.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+GRADLEW="$ROOT_DIR/gradlew"
+tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/fearless-utils-composite-default.XXXXXX")"
+trap 'rm -rf "$tmp_dir"' EXIT HUP INT TERM
+
+fail() {
+  echo "[fearless-utils-composite-default-test][error] $*" >&2
+  exit 1
+}
+
+run_composite() {
+  env \
+    -u FEARLESS_UTILS_LIBRARY_ONLY \
+    -u FEARLESS_UTILS_SKIP_RUST_PLUGIN \
+    CI=true \
+    SKIP_AUTO_VERSION_BUMP=true \
+    FORCE_LOCAL_UTILS=true \
+    USE_REMOTE_UTILS=false \
+    "$GRADLEW" :runtime:assembleDebugAndroidTest --dry-run --no-daemon --console=plain
+}
+
+run_standalone_override() {
+  env \
+    FEARLESS_UTILS_LIBRARY_ONLY=false \
+    FEARLESS_UTILS_SKIP_RUST_PLUGIN=true \
+    CI=true \
+    SKIP_AUTO_VERSION_BUMP=true \
+    FORCE_LOCAL_UTILS=true \
+    USE_REMOTE_UTILS=false \
+    "$GRADLEW" :runtime:assembleDebugAndroidTest --dry-run --no-daemon --console=plain
+}
+
+composite_log="$tmp_dir/composite.log"
+run_composite >"$composite_log" 2>&1 ||
+  fail "default composite mode did not configure the runtime instrumentation build"
+grep -Fq '> Configure project :fearless-utils-Android:fearless-utils' "$composite_log" ||
+  fail "default composite mode did not configure the substituted fearless-utils library"
+if grep -Fq '> Configure project :fearless-utils-Android:app' "$composite_log"; then
+  fail "default composite mode configured the unconsumed fearless-utils sample app"
+fi
+
+override_log="$tmp_dir/standalone-override.log"
+run_standalone_override >"$override_log" 2>&1 || true
+grep -Fq '> Configure project :fearless-utils-Android:app' "$override_log" ||
+  fail "an explicit false override no longer restores the standalone sample app"
+
+echo "[fearless-utils-composite-default-test] passed"

--- a/scripts/test-xcm-production-evidence-audit.sh
+++ b/scripts/test-xcm-production-evidence-audit.sh
@@ -3,6 +3,8 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 AUDIT_SCRIPT="$SCRIPT_DIR/audit-xcm-production-evidence.sh"
+ANDROID_COMMIT="0123456789abcdef0123456789abcdef01234567"
+STALE_ANDROID_COMMIT="89abcdef89abcdef89abcdef89abcdef89abcdef"
 
 fail() {
   echo "[xcm-production-evidence-test][error] $*" >&2
@@ -66,7 +68,8 @@ write_blocked_manifest() {
     "amount",
     "timestamp",
     "environment",
-    "operator"
+    "operator",
+    "androidCommit"
   ],
   "evidence": []
 }
@@ -109,7 +112,8 @@ write_ready_manifest() {
     "amount",
     "timestamp",
     "environment",
-    "operator"
+    "operator",
+    "androidCommit"
   ],
   "evidence": [
     {
@@ -122,7 +126,8 @@ write_ready_manifest() {
       "amount": "1",
       "timestamp": "2026-06-26T00:00:00Z",
       "environment": "mainnet",
-      "operator": "release"
+      "operator": "release",
+      "androidCommit": "0123456789abcdef0123456789abcdef01234567"
     },
     {
       "originChainId": "destination",
@@ -134,7 +139,8 @@ write_ready_manifest() {
       "amount": "1",
       "timestamp": "2026-06-26T00:00:00Z",
       "environment": "mainnet",
-      "operator": "release"
+      "operator": "release",
+      "androidCommit": "0123456789abcdef0123456789abcdef01234567"
     }
   ]
 }
@@ -146,7 +152,8 @@ run_audit() {
   local routes="$2"
   local gaps="$3"
   shift 3
-  bash "$AUDIT_SCRIPT" --evidence "$manifest" --required-route-file "$routes" --discovery-gap-file "$gaps" "$@"
+  XCM_PRODUCTION_EXPECTED_COMMIT="${XCM_PRODUCTION_EXPECTED_COMMIT:-$ANDROID_COMMIT}" \
+    bash "$AUDIT_SCRIPT" --evidence "$manifest" --required-route-file "$routes" --discovery-gap-file "$gaps" "$@"
 }
 
 expect_failure() {
@@ -241,6 +248,11 @@ cp "$blocked" "$missing_required_field"
 perl -0pi -e 's/"extrinsicHash",\n    //' "$missing_required_field"
 expect_failure "missing required evidence field" "requiredEvidenceFields missing extrinsicHash" run_audit "$missing_required_field" "$routes" "$gaps"
 
+missing_android_commit_field="$tmp_dir/missing-android-commit-field.json"
+cp "$blocked" "$missing_android_commit_field"
+perl -0pi -e 's/,\n    "androidCommit"//' "$missing_android_commit_field"
+expect_failure "missing Android commit evidence field" "requiredEvidenceFields missing androidCommit" run_audit "$missing_android_commit_field" "$routes" "$gaps"
+
 duplicate_required_field="$tmp_dir/duplicate-required-field.json"
 cp "$blocked" "$duplicate_required_field"
 node - "$duplicate_required_field" <<'NODE'
@@ -269,7 +281,7 @@ expect_failure "unsupported routeManifests XCM production evidence field" "unsup
 
 unsupported_required_evidence_field="$tmp_dir/unsupported-required-evidence-field.json"
 cp "$blocked" "$unsupported_required_evidence_field"
-perl -0pi -e 's/"operator"\n  \]/"operator",\n    "receiptUrl"\n  \]/' "$unsupported_required_evidence_field"
+perl -0pi -e 's/"androidCommit"\n  \]/"androidCommit",\n    "receiptUrl"\n  \]/' "$unsupported_required_evidence_field"
 expect_failure "unsupported required XCM production evidence field" "unsupported required XCM production evidence field" run_audit "$unsupported_required_evidence_field" "$routes" "$gaps"
 
 unsupported_blocker="$tmp_dir/unsupported-blocker.json"
@@ -356,6 +368,47 @@ ready_duplicate_hash="$tmp_dir/ready-duplicate-hash.json"
 cp "$ready" "$ready_duplicate_hash"
 perl -0pi -e 's/0xfedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210/0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef/' "$ready_duplicate_hash"
 expect_failure "ready evidence duplicate extrinsic hash" "duplicate E2E transfer extrinsicHash" run_audit "$ready_duplicate_hash" "$routes" "$empty_gaps" --require-ready
+
+ready_malformed_android_commit="$tmp_dir/ready-malformed-android-commit.json"
+cp "$ready" "$ready_malformed_android_commit"
+node - "$ready_malformed_android_commit" <<'NODE'
+const fs = require('fs');
+const file = process.argv[2];
+const manifest = JSON.parse(fs.readFileSync(file, 'utf8'));
+manifest.evidence[0].androidCommit = 'not-a-commit';
+fs.writeFileSync(file, `${JSON.stringify(manifest, null, 2)}\n`);
+NODE
+expect_failure "ready evidence malformed Android commit" "androidCommit must be a 40-character git commit" run_audit "$ready_malformed_android_commit" "$routes" "$empty_gaps" --require-ready
+
+ready_placeholder_android_commit="$tmp_dir/ready-placeholder-android-commit.json"
+cp "$ready" "$ready_placeholder_android_commit"
+node - "$ready_placeholder_android_commit" <<'NODE'
+const fs = require('fs');
+const file = process.argv[2];
+const manifest = JSON.parse(fs.readFileSync(file, 'utf8'));
+manifest.evidence[0].androidCommit = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+fs.writeFileSync(file, `${JSON.stringify(manifest, null, 2)}\n`);
+NODE
+expect_failure "ready evidence placeholder Android commit" "androidCommit must not be a placeholder Android release commit" run_audit "$ready_placeholder_android_commit" "$routes" "$empty_gaps" --require-ready
+
+ready_stale_android_commit="$tmp_dir/ready-stale-android-commit.json"
+cp "$ready" "$ready_stale_android_commit"
+node - "$ready_stale_android_commit" "$STALE_ANDROID_COMMIT" <<'NODE'
+const fs = require('fs');
+const [file, staleCommit] = process.argv.slice(2);
+const manifest = JSON.parse(fs.readFileSync(file, 'utf8'));
+manifest.evidence[0].androidCommit = staleCommit;
+fs.writeFileSync(file, `${JSON.stringify(manifest, null, 2)}\n`);
+NODE
+expect_failure "ready evidence stale Android commit" "androidCommit must match expected Android release commit $ANDROID_COMMIT" run_audit "$ready_stale_android_commit" "$routes" "$empty_gaps" --require-ready
+
+expect_failure "malformed expected Android commit override" "XCM_PRODUCTION_EXPECTED_COMMIT must be a 40-character git commit" \
+  env XCM_PRODUCTION_EXPECTED_COMMIT=not-a-commit bash "$AUDIT_SCRIPT" --evidence "$ready" --required-route-file "$routes" --discovery-gap-file "$empty_gaps" --require-ready
+
+no_git_root="$tmp_dir/no-git-root"
+mkdir "$no_git_root"
+expect_failure "missing expected Android commit source" "ready XCM production evidence requires XCM_PRODUCTION_EXPECTED_COMMIT or a local Android git HEAD source" \
+  env -u XCM_PRODUCTION_EXPECTED_COMMIT XCM_PRODUCTION_EVIDENCE_ROOT="$no_git_root" bash "$AUDIT_SCRIPT" --evidence "$ready" --required-route-file "$routes" --discovery-gap-file "$empty_gaps" --require-ready
 
 ready_future_timestamp="$tmp_dir/ready-future-timestamp.json"
 cp "$ready" "$ready_future_timestamp"

--- a/scripts/test-xcm-production-evidence-template.sh
+++ b/scripts/test-xcm-production-evidence-template.sh
@@ -74,7 +74,8 @@ assert.deepEqual(template.requiredEvidenceFields, [
   'amount',
   'timestamp',
   'environment',
-  'operator'
+  'operator',
+  'androidCommit'
 ]);
 assert.equal(template.evidence.length, 2);
 assert.deepEqual(template.evidence[0], {
@@ -87,9 +88,11 @@ assert.deepEqual(template.evidence[0], {
   amount: 'TODO_positive_decimal_amount',
   timestamp: 'TODO_YYYY-MM-DDTHH:MM:SSZ',
   environment: 'mainnet',
-  operator: 'TODO_operator_or_runbook_id'
+  operator: 'TODO_operator_or_runbook_id',
+  androidCommit: 'TODO_android_release_commit'
 });
 assert.equal(template.evidence[1].assetSymbol, 'KSM');
+assert.equal(template.evidence[1].androidCommit, 'TODO_android_release_commit');
 
 function assertNoSecretLikeKeys(value, path = '$') {
   if (!value || typeof value !== 'object') {

--- a/scripts/xcm-production-evidence.json
+++ b/scripts/xcm-production-evidence.json
@@ -37,7 +37,8 @@
     "amount",
     "timestamp",
     "environment",
-    "operator"
+    "operator",
+    "androidCommit"
   ],
   "evidence": []
 }


### PR DESCRIPTION
## Summary
- require Android XCM production evidence records to carry androidCommit
- compare ready evidence against the Android release commit or XCM_PRODUCTION_EXPECTED_COMMIT
- update the evidence template, release checklist, and adversarial tests

## Verification
- bash -n scripts/audit-xcm-production-evidence.sh scripts/generate-xcm-production-evidence-template.sh scripts/test-xcm-production-evidence-audit.sh scripts/test-xcm-production-evidence-template.sh
- bash scripts/test-xcm-production-evidence-template.sh
- bash scripts/test-xcm-production-evidence-audit.sh
- bash scripts/audit-xcm-production-evidence.sh
- bash scripts/generate-xcm-production-evidence-template.sh --output build/reports/xcm-production-evidence-template.json
- git diff --check